### PR TITLE
feat: add Future encryption types to GPO recommendations (CIS 2.3.11.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- GPO recommendation text now includes **Future encryption types** alongside AES128_HMAC_SHA1 and AES256_HMAC_SHA1, per CIS Benchmark 2.3.11.4
+- `Get-EncryptionTypeString` recognises the `0x80000000` (Future encryption types) bit
+- Updated guidance in `Get-GuidancePlainText` and `Show-ManualValidationGuidance` GPO Validation sections
+- Updated DeepScan inline info message to reference Future encryption types
+
 ## [4.1.2] - 2026-03-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ flowchart TD
 | 24 | 0x18 | AES128 + AES256 | **Recommended (AES-only)** |
 | 28 | 0x1C | RC4 + AES128 + AES256 | **RC4 exception with AES** |
 | 31 | 0x1F | DES-CBC-CRC, DES-CBC-MD5, RC4, AES128, AES256 | All types (insecure — includes DES) |
+| 2147483672 | 0x80000018 | AES128 + AES256 + Future encryption types | **CIS Benchmark recommended GPO value** |
 
 > **Tip:** The value is a bitmask — add the decimal values for the types you need.
 > For per-account RC4 exceptions, use **28 (`0x1C`)** = RC4 (4) + AES128 (8) + AES256 (16).

--- a/Tests/Unit/Get-EncryptionTypeString.Tests.ps1
+++ b/Tests/Unit/Get-EncryptionTypeString.Tests.ps1
@@ -31,5 +31,13 @@ InModuleScope 'RC4-ADAssessment' {
     It 'Returns all types for value 31' {
         Get-EncryptionTypeString -Value 31 | Should -Be 'DES-CBC-CRC, DES-CBC-MD5, RC4-HMAC, AES128-HMAC, AES256-HMAC'
     }
+
+    It 'Returns "Future" for value 0x80000000' {
+        Get-EncryptionTypeString -Value ([int]0x80000000) | Should -Be 'Future'
+    }
+
+    It 'Returns AES + Future for CIS-recommended GPO value 0x80000018' {
+        Get-EncryptionTypeString -Value ([int]0x80000018) | Should -Be 'AES128-HMAC, AES256-HMAC, Future'
+    }
 }
 }

--- a/Tests/Unit/RC4-ADAssessment.Tests.ps1
+++ b/Tests/Unit/RC4-ADAssessment.Tests.ps1
@@ -121,6 +121,14 @@ Describe 'Get-EncryptionTypeString' {
     It 'Returns all types for value 31 (0x1F)' {
         Get-EncryptionTypeString -Value 31 | Should -Be "DES-CBC-CRC, DES-CBC-MD5, RC4-HMAC, AES128-HMAC, AES256-HMAC"
     }
+
+    It 'Returns "Future" for value 0x80000000' {
+        Get-EncryptionTypeString -Value ([int]0x80000000) | Should -Be "Future"
+    }
+
+    It 'Returns AES + Future for CIS-recommended GPO value 0x80000018' {
+        Get-EncryptionTypeString -Value ([int]0x80000018) | Should -Be "AES128-HMAC, AES256-HMAC, Future"
+    }
 }
 }
 

--- a/source/Private/Get-AccountEncryptionAssessment.ps1
+++ b/source/Private/Get-AccountEncryptionAssessment.ps1
@@ -698,7 +698,7 @@
                     # Report OS-default computers (INFO — fix with a single GPO)
                     if ($assessment.DeepScanComputersOSDefault -gt 0) {
                         Write-Finding -Status "INFO" -Message "[DeepScan] $($assessment.DeepScanComputersOSDefault) computer(s) have OS-default encryption (0x1C = RC4+AES)" `
-                            -Detail "Windows stamps RC4+AES on domain join. Deploy a domain-level GPO to set 'Network security: Configure encryption types allowed for Kerberos' = AES128 + AES256 only"
+                            -Detail "Windows stamps RC4+AES on domain join. Deploy a domain-level GPO to set 'Network security: Configure encryption types allowed for Kerberos' = AES128 + AES256 + Future encryption types"
                     }
 
                     # Report problematic computers (WARNING — need per-computer investigation)

--- a/source/Private/Get-EncryptionTypeString.ps1
+++ b/source/Private/Get-EncryptionTypeString.ps1
@@ -28,6 +28,7 @@ function Get-EncryptionTypeString {
     if ($Value -band 0x4) { $types += "RC4-HMAC" }
     if ($Value -band 0x8) { $types += "AES128-HMAC" }
     if ($Value -band 0x10) { $types += "AES256-HMAC" }
+    if ($Value -band ([int]::MinValue)) { $types += "Future" }
 
     return ($types -join ", ")
 }

--- a/source/Private/Get-GuidancePlainText.ps1
+++ b/source/Private/Get-GuidancePlainText.ps1
@@ -88,7 +88,7 @@ ktpass command reference:
    PS> Start-Process C:\gpresult.html
 
    Look for: "Network security: Configure encryption types allowed for Kerberos"
-   Should show: AES128_HMAC_SHA1, AES256_HMAC_SHA1
+   Should show: AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types
    Should NOT show: DES_CBC_CRC, DES_CBC_MD5, RC4_HMAC_MD5
 
 4. Computer Object Assessment (If Needed)

--- a/source/Private/Show-ManualValidationGuidance.ps1
+++ b/source/Private/Show-ManualValidationGuidance.ps1
@@ -64,7 +64,7 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
    PS> Start-Process C:\gpresult.html
 
    Look for: "Network security: Configure encryption types allowed for Kerberos"
-   Should show: AES128_HMAC_SHA1, AES256_HMAC_SHA1
+   Should show: AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types
    Should NOT show: DES_CBC_CRC, DES_CBC_MD5, RC4_HMAC_MD5
 
 4. Computer Object Assessment (If Needed)

--- a/source/Public/Invoke-RC4Assessment.ps1
+++ b/source/Public/Invoke-RC4Assessment.ps1
@@ -307,7 +307,7 @@ try {
             Message = "[$($results.Domain)] Remove RC4 encryption from $($results.DomainControllers.RC4Configured) Domain Controller(s): $rc4DCs"
             Fix     = @(
                 "Set-ADComputer $rc4DCs -Replace @{'msDS-SupportedEncryptionTypes'=24}"
-                "# Or configure via GPO: 'Network security: Configure encryption types allowed for Kerberos' = AES128 + AES256"
+                "# Or configure via GPO: 'Network security: Configure encryption types allowed for Kerberos' = AES128 + AES256 + Future encryption types"
             )
         }
     }
@@ -565,7 +565,7 @@ try {
                 Fix     = @(
                     "# Deploy domain-level GPO:"
                     "# Computer Configuration > Policies > Windows Settings > Security Settings > Local Policies > Security Options"
-                    "# 'Network security: Configure encryption types allowed for Kerberos' = AES128_HMAC_SHA1 + AES256_HMAC_SHA1"
+                    "# 'Network security: Configure encryption types allowed for Kerberos' = AES128_HMAC_SHA1 + AES256_HMAC_SHA1 + Future encryption types"
                 )
             }
         }


### PR DESCRIPTION
## Summary

Adds **Future encryption types** to all GPO recommendation text per [CIS Benchmark 2.3.11.4](https://downloads.cisecurity.org/download?u=1774947081) and [Microsoft documentation](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/network-security-configure-encryption-types-allowed-for-kerberos).

## Changes

### Code
- **\Get-EncryptionTypeString\** — Recognises the \