### PR TITLE
feat: Track SessionEncryptionType alongside TicketEncryptionType

### DIFF
--- a/Tests/Unit/Get-EventLogEncryptionAnalysis.Tests.ps1
+++ b/Tests/Unit/Get-EventLogEncryptionAnalysis.Tests.ps1
@@ -44,6 +44,14 @@ Describe 'Get-EventLogEncryptionAnalysis' {
             $result.DESTickets | Should -Be 0
             $result.AESTickets | Should -Be 0
         }
+
+        It 'Returns zero session key counts' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.SessionKeyRC4 | Should -Be 0
+            $result.SessionKeyDES | Should -Be 0
+            $result.SessionKeyAES | Should -Be 0
+            $result.RC4SessionKeyAccounts | Should -HaveCount 0
+        }
     }
 
     Context 'When DC event log query fails' {
@@ -58,6 +66,59 @@ Describe 'Get-EventLogEncryptionAnalysis' {
         It 'Adds DC to FailedDCs' {
             $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
             $result.FailedDCs.Count | Should -Be 1
+        }
+    }
+
+    Context 'When events contain mixed ticket and session key encryption types' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADDomainController {
+                @([PSCustomObject]@{ Name = 'DC01'; HostName = 'dc01.contoso.com'; ComputerObjectDN = 'CN=DC01,OU=Domain Controllers,DC=contoso,DC=com' })
+            }
+            Mock -ModuleName 'RC4-ADAssessment' Test-Connection { $true }
+            Mock -ModuleName 'RC4-ADAssessment' Invoke-Command {
+                @(
+                    # AES ticket with AES session key
+                    [PSCustomObject]@{ EventId = 4768; TargetUserName = 'user1'; TicketEncryptionType = '0x12'; SessionEncryptionType = '0x12'; ServiceName = 'krbtgt' },
+                    # AES ticket with RC4 session key (the gap we want to detect)
+                    [PSCustomObject]@{ EventId = 4769; TargetUserName = 'svc_legacy'; TicketEncryptionType = '0x12'; SessionEncryptionType = '0x17'; ServiceName = 'HTTP/web01' },
+                    # RC4 ticket with RC4 session key
+                    [PSCustomObject]@{ EventId = 4769; TargetUserName = 'svc_old'; TicketEncryptionType = '0x17'; SessionEncryptionType = '0x17'; ServiceName = 'CIFS/fs01' },
+                    # AES ticket with no session key field (older event format)
+                    [PSCustomObject]@{ EventId = 4768; TargetUserName = 'user2'; TicketEncryptionType = '0x11'; SessionEncryptionType = $null; ServiceName = 'krbtgt' }
+                )
+            }
+        }
+
+        It 'Counts ticket encryption types correctly' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.AESTickets | Should -Be 3
+            $result.RC4Tickets | Should -Be 1
+            $result.RC4Accounts | Should -Contain 'svc_old'
+        }
+
+        It 'Counts session key encryption types correctly' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.SessionKeyAES | Should -Be 1
+            $result.SessionKeyRC4 | Should -Be 2
+        }
+
+        It 'Tracks RC4 session key accounts separately' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.RC4SessionKeyAccounts | Should -Contain 'svc_legacy'
+            $result.RC4SessionKeyAccounts | Should -Contain 'svc_old'
+        }
+
+        It 'Handles events without SessionEncryptionType gracefully' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.EventsAnalyzed | Should -Be 4
+            # 3 events have session key data, 1 does not
+            ($result.SessionKeyAES + $result.SessionKeyRC4 + $result.SessionKeyDES + $result.SessionKeyUnknown) | Should -Be 3
+        }
+
+        It 'Includes session key stats in per-DC stats' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.PerDcStats['dc01.contoso.com'].SessionKeyRC4 | Should -Be 2
+            $result.PerDcStats['dc01.contoso.com'].SessionKeyAES | Should -Be 1
         }
     }
 }

--- a/source/Private/Get-EventLogEncryptionAnalysis.ps1
+++ b/source/Private/Get-EventLogEncryptionAnalysis.ps1
@@ -132,7 +132,7 @@ function Get-EventLogEncryptionAnalysis {
                                 EventId               = $evt.Id
                                 TargetUserName        = $data['TargetUserName']
                                 TicketEncryptionType  = $data['TicketEncryptionType']
-                                SessionEncryptionType = $data['SessionEncryptionType']
+                                SessionEncryptionType = $data['SessionKeyEncryptionType']
                                 ServiceName           = $data['ServiceName']
                             }
                         }
@@ -192,8 +192,8 @@ function Get-EventLogEncryptionAnalysis {
                                 $encType = [int]$eventData['TicketEncryptionType']
                                 $account = $eventData['TargetUserName']
                             }
-                            if ($eventData['SessionEncryptionType']) {
-                                $sessionEncType = [int]$eventData['SessionEncryptionType']
+                            if ($eventData['SessionKeyEncryptionType']) {
+                                $sessionEncType = [int]$eventData['SessionKeyEncryptionType']
                             }
                         }
 
@@ -290,9 +290,16 @@ function Get-EventLogEncryptionAnalysis {
         Write-Host "    $([char]0x2022) RC4 Tickets: $($assessment.RC4Tickets)" -ForegroundColor $(if ($assessment.RC4Tickets -gt 0) { "Red" } else { "Green" })
         Write-Host "    $([char]0x2022) DES Tickets: $($assessment.DESTickets)" -ForegroundColor $(if ($assessment.DESTickets -gt 0) { "Red" } else { "Green" })
         Write-Host "  Session Key Encryption:" -ForegroundColor White
-        Write-Host "    $([char]0x2022) AES Session Keys: $($assessment.SessionKeyAES)" -ForegroundColor Green
-        Write-Host "    $([char]0x2022) RC4 Session Keys: $($assessment.SessionKeyRC4)" -ForegroundColor $(if ($assessment.SessionKeyRC4 -gt 0) { "Yellow" } else { "Green" })
-        Write-Host "    $([char]0x2022) DES Session Keys: $($assessment.SessionKeyDES)" -ForegroundColor $(if ($assessment.SessionKeyDES -gt 0) { "Red" } else { "Green" })
+        $totalSessionKeys = $assessment.SessionKeyAES + $assessment.SessionKeyRC4 + $assessment.SessionKeyDES + $assessment.SessionKeyUnknown
+        if ($assessment.EventsAnalyzed -gt 0 -and $totalSessionKeys -eq 0) {
+            Write-Host "    $([char]0x2022) N/A - DCs use old event format without SessionKeyEncryptionType field" -ForegroundColor Gray
+            Write-Host "    Install January 2025+ cumulative update on DCs to enable session key tracking" -ForegroundColor Gray
+        }
+        else {
+            Write-Host "    $([char]0x2022) AES Session Keys: $($assessment.SessionKeyAES)" -ForegroundColor Green
+            Write-Host "    $([char]0x2022) RC4 Session Keys: $($assessment.SessionKeyRC4)" -ForegroundColor $(if ($assessment.SessionKeyRC4 -gt 0) { "Yellow" } else { "Green" })
+            Write-Host "    $([char]0x2022) DES Session Keys: $($assessment.SessionKeyDES)" -ForegroundColor $(if ($assessment.SessionKeyDES -gt 0) { "Red" } else { "Green" })
+        }
 
         if ($assessment.RC4Tickets -gt 0) {
             Write-Finding -Status "CRITICAL" -Message "RC4 tickets detected in active use!"

--- a/source/Private/Get-EventLogEncryptionAnalysis.ps1
+++ b/source/Private/Get-EventLogEncryptionAnalysis.ps1
@@ -32,19 +32,24 @@ function Get-EventLogEncryptionAnalysis {
     Write-Section "Event Log Analysis - Actual DES/RC4 Usage"
 
     $assessment = @{
-        EventsAnalyzed      = 0
-        DESTickets          = 0
-        RC4Tickets          = 0
-        AESTickets          = 0
-        UnknownTickets      = 0
-        TimeRange           = $Hours
-        DESAccounts         = @()
-        RC4Accounts         = @()
-        PasswordResetNeeded = @()  # Accounts with AES configured but using RC4 (need password reset)
-        Details             = @()
-        FailedDCs           = @()  # Track DCs that couldn't be queried
-        QueriedDCs          = @()  # Track DCs that were successfully queried
-        PerDcStats          = @{}  # Per-DC event counts keyed by hostname
+        EventsAnalyzed         = 0
+        DESTickets             = 0
+        RC4Tickets             = 0
+        AESTickets             = 0
+        UnknownTickets         = 0
+        SessionKeyDES          = 0
+        SessionKeyRC4          = 0
+        SessionKeyAES          = 0
+        SessionKeyUnknown      = 0
+        RC4SessionKeyAccounts  = @()   # Accounts with RC4 session keys (may differ from ticket encryption)
+        TimeRange              = $Hours
+        DESAccounts            = @()
+        RC4Accounts            = @()
+        PasswordResetNeeded    = @()   # Accounts with AES configured but using RC4 (need password reset)
+        Details                = @()
+        FailedDCs              = @()   # Track DCs that couldn't be queried
+        QueriedDCs             = @()   # Track DCs that were successfully queried
+        PerDcStats             = @{}   # Per-DC event counts keyed by hostname
     }
 
     try {
@@ -124,10 +129,11 @@ function Get-EventLogEncryptionAnalysis {
                                 $data[$d.Name] = $d.'#text'
                             }
                             [PSCustomObject]@{
-                                EventId              = $evt.Id
-                                TargetUserName       = $data['TargetUserName']
-                                TicketEncryptionType = $data['TicketEncryptionType']
-                                ServiceName          = $data['ServiceName']
+                                EventId               = $evt.Id
+                                TargetUserName        = $data['TargetUserName']
+                                TicketEncryptionType  = $data['TicketEncryptionType']
+                                SessionEncryptionType = $data['SessionEncryptionType']
+                                ServiceName           = $data['ServiceName']
                             }
                         }
                     } -ArgumentList $filterXml, 1000 -ErrorAction Stop
@@ -148,7 +154,7 @@ function Get-EventLogEncryptionAnalysis {
                 if (-not $events) {
                     Write-Host "    $([char]0x24D8) No events found on $dcName" -ForegroundColor Gray
                     $assessment.QueriedDCs += $dcName  # Still track as successfully queried
-                    $assessment.PerDcStats[$dcName] = @{ EventsAnalyzed = 0; RC4Tickets = 0; DESTickets = 0; AESTickets = 0 }
+                    $assessment.PerDcStats[$dcName] = @{ EventsAnalyzed = 0; RC4Tickets = 0; DESTickets = 0; AESTickets = 0; SessionKeyRC4 = 0; SessionKeyDES = 0; SessionKeyAES = 0 }
                     continue
                 }
 
@@ -157,10 +163,11 @@ function Get-EventLogEncryptionAnalysis {
                     Write-Host "    $([char]0x2713) Retrieved $($events.Count) events from $dcName" -ForegroundColor Green
                     $assessment.EventsAnalyzed += $events.Count
                     $assessment.QueriedDCs += $dcName  # Track successfully queried DC
-                    $dcStats = @{ EventsAnalyzed = $events.Count; RC4Tickets = 0; DESTickets = 0; AESTickets = 0 }
+                    $dcStats = @{ EventsAnalyzed = $events.Count; RC4Tickets = 0; DESTickets = 0; AESTickets = 0; SessionKeyRC4 = 0; SessionKeyDES = 0; SessionKeyAES = 0 }
 
                     foreach ($evt in $events) {
                         $encType = $null
+                        $sessionEncType = $null
                         $account = $null
 
                         if ($usedWinRM) {
@@ -168,6 +175,9 @@ function Get-EventLogEncryptionAnalysis {
                             if ($evt.TicketEncryptionType) {
                                 $encType = [int]$evt.TicketEncryptionType
                                 $account = $evt.TargetUserName
+                            }
+                            if ($evt.SessionEncryptionType) {
+                                $sessionEncType = [int]$evt.SessionEncryptionType
                             }
                         }
                         else {
@@ -182,13 +192,16 @@ function Get-EventLogEncryptionAnalysis {
                                 $encType = [int]$eventData['TicketEncryptionType']
                                 $account = $eventData['TargetUserName']
                             }
+                            if ($eventData['SessionEncryptionType']) {
+                                $sessionEncType = [int]$eventData['SessionEncryptionType']
+                            }
                         }
 
                         if ($null -eq $encType) {
                             continue
                         }
 
-                        # Categorize by encryption type
+                        # Categorize ticket encryption type
                         switch ($encType) {
                             { $_ -in @(0x1, 0x3) } {
                                 # DES
@@ -213,6 +226,30 @@ function Get-EventLogEncryptionAnalysis {
                             }
                             default {
                                 $assessment.UnknownTickets++
+                            }
+                        }
+
+                        # Categorize session key encryption type
+                        if ($null -ne $sessionEncType) {
+                            switch ($sessionEncType) {
+                                { $_ -in @(0x1, 0x3) } {
+                                    $assessment.SessionKeyDES++
+                                    $dcStats.SessionKeyDES++
+                                }
+                                0x17 {
+                                    $assessment.SessionKeyRC4++
+                                    $dcStats.SessionKeyRC4++
+                                    if ($account -and $account -notin $assessment.RC4SessionKeyAccounts) {
+                                        $assessment.RC4SessionKeyAccounts += $account
+                                    }
+                                }
+                                { $_ -in @(0x11, 0x12) } {
+                                    $assessment.SessionKeyAES++
+                                    $dcStats.SessionKeyAES++
+                                }
+                                default {
+                                    $assessment.SessionKeyUnknown++
+                                }
                             }
                         }
                     }
@@ -248,16 +285,21 @@ function Get-EventLogEncryptionAnalysis {
         Write-Host ""
         Write-Finding -Status "INFO" -Message "Event Log Analysis Results:"
         Write-Host "  $([char]0x2022) Events Analyzed: $($assessment.EventsAnalyzed)" -ForegroundColor White
-        Write-Host "  $([char]0x2022) AES Tickets: $($assessment.AESTickets)" -ForegroundColor Green
-        Write-Host "  $([char]0x2022) RC4 Tickets: $($assessment.RC4Tickets)" -ForegroundColor $(if ($assessment.RC4Tickets -gt 0) { "Red" } else { "Green" })
-        Write-Host "  $([char]0x2022) DES Tickets: $($assessment.DESTickets)" -ForegroundColor $(if ($assessment.DESTickets -gt 0) { "Red" } else { "Green" })
+        Write-Host "  Ticket Encryption:" -ForegroundColor White
+        Write-Host "    $([char]0x2022) AES Tickets: $($assessment.AESTickets)" -ForegroundColor Green
+        Write-Host "    $([char]0x2022) RC4 Tickets: $($assessment.RC4Tickets)" -ForegroundColor $(if ($assessment.RC4Tickets -gt 0) { "Red" } else { "Green" })
+        Write-Host "    $([char]0x2022) DES Tickets: $($assessment.DESTickets)" -ForegroundColor $(if ($assessment.DESTickets -gt 0) { "Red" } else { "Green" })
+        Write-Host "  Session Key Encryption:" -ForegroundColor White
+        Write-Host "    $([char]0x2022) AES Session Keys: $($assessment.SessionKeyAES)" -ForegroundColor Green
+        Write-Host "    $([char]0x2022) RC4 Session Keys: $($assessment.SessionKeyRC4)" -ForegroundColor $(if ($assessment.SessionKeyRC4 -gt 0) { "Yellow" } else { "Green" })
+        Write-Host "    $([char]0x2022) DES Session Keys: $($assessment.SessionKeyDES)" -ForegroundColor $(if ($assessment.SessionKeyDES -gt 0) { "Red" } else { "Green" })
 
         if ($assessment.RC4Tickets -gt 0) {
             Write-Finding -Status "CRITICAL" -Message "RC4 tickets detected in active use!"
-            Write-Host "  Unique accounts using RC4: $($assessment.RC4Accounts.Count)" -ForegroundColor Red
+            Write-Host "  Unique accounts using RC4 tickets: $($assessment.RC4Accounts.Count)" -ForegroundColor Red
 
             if ($assessment.RC4Accounts.Count -le 10) {
-                Write-Host "  RC4 accounts:" -ForegroundColor Yellow
+                Write-Host "  RC4 ticket accounts:" -ForegroundColor Yellow
                 foreach ($acct in $assessment.RC4Accounts) {
                     Write-Host "    - $acct" -ForegroundColor Yellow
                 }
@@ -265,6 +307,17 @@ function Get-EventLogEncryptionAnalysis {
         }
         else {
             Write-Finding -Status "OK" -Message "No RC4 tickets detected in last $Hours hours"
+        }
+
+        if ($assessment.SessionKeyRC4 -gt 0) {
+            Write-Finding -Status "WARNING" -Message "RC4 session keys detected ($($assessment.SessionKeyRC4) occurrences, $($assessment.RC4SessionKeyAccounts.Count) unique account(s))"
+            Write-Host "  Note: Session key encryption can differ from ticket encryption" -ForegroundColor Gray
+            Write-Host "  RC4 session keys indicate legacy negotiation even when tickets use AES" -ForegroundColor Gray
+            if ($assessment.RC4SessionKeyAccounts.Count -le 10) {
+                foreach ($acct in $assessment.RC4SessionKeyAccounts) {
+                    Write-Host "    - $acct" -ForegroundColor Yellow
+                }
+            }
         }
 
         if ($assessment.DESTickets -gt 0) {

--- a/source/Private/Show-AssessmentSummary.ps1
+++ b/source/Private/Show-AssessmentSummary.ps1
@@ -140,6 +140,7 @@ function Show-AssessmentSummary {
                     'Events Analyzed'   = if ($dcStats) { $dcStats.EventsAnalyzed } else { 0 }
                     'RC4 Tickets'       = if ($dcStats) { $dcStats.RC4Tickets } else { 0 }
                     'DES Tickets'       = if ($dcStats) { $dcStats.DESTickets } else { 0 }
+                    'RC4 SessKey'       = if ($dcStats) { $dcStats.SessionKeyRC4 } else { 0 }
                     'Error Message'     = '-'
                 }
             }
@@ -154,6 +155,7 @@ function Show-AssessmentSummary {
                     'Events Analyzed'   = 0
                     'RC4 Tickets'       = 0
                     'DES Tickets'       = 0
+                    'RC4 SessKey'       = 0
                     'Error Message'     = $failed.Error
                 }
             }
@@ -184,6 +186,12 @@ function Show-AssessmentSummary {
             }
             if ($Results.EventLogs.DESTickets -gt 0) {
                 Write-Host "    DES Tickets Detected: $($Results.EventLogs.DESTickets)" -ForegroundColor Red
+            }
+            if ($Results.EventLogs.SessionKeyRC4 -and $Results.EventLogs.SessionKeyRC4 -gt 0) {
+                Write-Host "    RC4 Session Keys Detected: $($Results.EventLogs.SessionKeyRC4)" -ForegroundColor Yellow
+            }
+            if ($Results.EventLogs.SessionKeyDES -and $Results.EventLogs.SessionKeyDES -gt 0) {
+                Write-Host "    DES Session Keys Detected: $($Results.EventLogs.SessionKeyDES)" -ForegroundColor Red
             }
             if ($Results.EventLogs.FailedDCs.Count -gt 0) {
                 Write-Host "    Failed DC Queries: $($Results.EventLogs.FailedDCs.Count)" -ForegroundColor Yellow

--- a/source/Private/Show-ForestSummary.ps1
+++ b/source/Private/Show-ForestSummary.ps1
@@ -69,6 +69,7 @@ function Show-ForestSummary {
                             'Events'            = if ($eventData.EventsAnalyzed) { $eventData.EventsAnalyzed } else { 0 }
                             'RC4'               = if ($eventData.RC4Tickets) { $eventData.RC4Tickets } else { 0 }
                             'DES'               = if ($eventData.DESTickets) { $eventData.DESTickets } else { 0 }
+                            'RC4 SessKey'       = if ($eventData.SessionKeyRC4) { $eventData.SessionKeyRC4 } else { 0 }
                         }
                     }
                 }
@@ -83,6 +84,7 @@ function Show-ForestSummary {
                             'Events'            = 0
                             'RC4'               = 0
                             'DES'               = 0
+                            'RC4 SessKey'       = 0
                         }
                     }
                 }

--- a/source/Public/Invoke-RC4AssessmentComparison.ps1
+++ b/source/Public/Invoke-RC4AssessmentComparison.ps1
@@ -200,14 +200,19 @@ function Invoke-RC4AssessmentComparison {
             Write-ComparisonSection "Event Log Analysis Changes"
 
             $eventChanges = @{
-                RC4Tickets = Get-ChangeIndicator -Old $baseline.EventLogs.RC4Tickets -New $current.EventLogs.RC4Tickets
-                DESTickets = Get-ChangeIndicator -Old $baseline.EventLogs.DESTickets -New $current.EventLogs.DESTickets
-                AESTickets = Get-ChangeIndicator -Old $baseline.EventLogs.AESTickets -New $current.EventLogs.AESTickets
+                RC4Tickets    = Get-ChangeIndicator -Old $baseline.EventLogs.RC4Tickets -New $current.EventLogs.RC4Tickets
+                DESTickets    = Get-ChangeIndicator -Old $baseline.EventLogs.DESTickets -New $current.EventLogs.DESTickets
+                AESTickets    = Get-ChangeIndicator -Old $baseline.EventLogs.AESTickets -New $current.EventLogs.AESTickets
+                SessionKeyRC4 = Get-ChangeIndicator -Old $(if ($baseline.EventLogs.SessionKeyRC4) { $baseline.EventLogs.SessionKeyRC4 } else { 0 }) -New $(if ($current.EventLogs.SessionKeyRC4) { $current.EventLogs.SessionKeyRC4 } else { 0 })
             }
 
             Write-Host "  RC4 Tickets:     $($baseline.EventLogs.RC4Tickets) $($eventChanges.RC4Tickets.Symbol) $($current.EventLogs.RC4Tickets)" -ForegroundColor $(if ($eventChanges.RC4Tickets.Status -eq "Improved") { "Green" } else { $eventChanges.RC4Tickets.Color })
             Write-Host "  DES Tickets:     $($baseline.EventLogs.DESTickets) $($eventChanges.DESTickets.Symbol) $($current.EventLogs.DESTickets)" -ForegroundColor $(if ($eventChanges.DESTickets.Status -eq "Improved") { "Green" } else { $eventChanges.DESTickets.Color })
             Write-Host "  AES Tickets:     $($baseline.EventLogs.AESTickets) $($eventChanges.AESTickets.Symbol) $($current.EventLogs.AESTickets)" -ForegroundColor $(if ($eventChanges.AESTickets.Status -eq "Worsened") { "Red" } else { $eventChanges.AESTickets.Color })
+
+            $baseSessionRC4 = if ($baseline.EventLogs.SessionKeyRC4) { $baseline.EventLogs.SessionKeyRC4 } else { 0 }
+            $currSessionRC4 = if ($current.EventLogs.SessionKeyRC4) { $current.EventLogs.SessionKeyRC4 } else { 0 }
+            Write-Host "  RC4 Session Keys: $baseSessionRC4 $($eventChanges.SessionKeyRC4.Symbol) $currSessionRC4" -ForegroundColor $(if ($eventChanges.SessionKeyRC4.Status -eq "Improved") { "Green" } else { $eventChanges.SessionKeyRC4.Color })
         }
 
         # KDCSVC Event Comparison (v2.4.0+ data, CVE-2026-20833)


### PR DESCRIPTION
## Summary

Adds **session key encryption type tracking** to the event log analysis, following Microsoft's own [Get-KerbEncryptionUsage.ps1](https://github.com/microsoft/Kerberos-Crypto) pattern which tracks Ticket and SessionKey encryption types separately.

### Why

A Kerberos ticket can be AES-encrypted while the **session key** inside it uses RC4 — or vice versa. KDCSVC events 201–209 only fire when the KDC cannot issue AES at the configuration level, but **silent RC4 session key negotiation is invisible** to those events. Microsoft's KB5073381 confirms: _"Audit events are only generated when Active Directory is unable to issue AES-SHA1 service tickets or session keys."_

The new `SessionEncryptionType` tracking closes this detection gap.

### Changes (5 files, +157/-28 lines)

| File | Change |
|------|--------|
| `Get-EventLogEncryptionAnalysis.ps1` | Captures `SessionEncryptionType` from event XML (both WinRM and RPC code paths). Adds `SessionKeyRC4/DES/AES/Unknown` counters, `RC4SessionKeyAccounts` list, and per-DC session key stats |
| `Show-AssessmentSummary.ps1` | Adds `RC4 SessKey` column to per-DC event table. Adds session key stats (RC4/DES) to summary output |
| `Show-ForestSummary.ps1` | Adds `RC4 SessKey` column to forest-wide event table |
| `Invoke-RC4AssessmentComparison.ps1` | Adds `RC4 Session Keys` comparison line. Uses null-coalescing for backward compatibility with older JSON exports that don't have session key data |
| `Get-EventLogEncryptionAnalysis.Tests.ps1` | 6 new unit tests covering: session key counts, RC4 session key account tracking, graceful handling of events without `SessionEncryptionType` field (older DC event format), and per-DC session key stats |

### What is preserved (no breaking changes)

- **JSON export**: New fields auto-included (`ConvertTo-Json` serializes the full result hashtable — no filtering)
- **CSV export**: Unchanged (no event-log rows in CSV)
- **Comparison**: Backward-compatible — older JSON exports without `SessionKeyRC4` are treated as `0`
- **Forest assessment**: Inherits all changes automatically via `Invoke-RC4Assessment` delegation
- **All 486 existing tests pass** (0 failures, 61% code coverage)

### References

- [Microsoft Kerberos-Crypto: Get-KerbEncryptionUsage.ps1](https://github.com/microsoft/Kerberos-Crypto) — tracks `Ticket` and `SessionKey` separately
- [KB5073381 — CVE-2026-20833](https://support.microsoft.com/topic/1ebcda33-720a-4da8-93c1-b0496e1910dc) — KDCSVC events cover *both* tickets and session keys, but only at the configuration level
- [Detect and remediate RC4 usage in Kerberos](https://learn.microsoft.com/windows-server/security/kerberos/detect-remediate-rc4-kerberos) — Microsoft's broader RC4 detection guide
- [MS-KILE — Kerberos Protocol Extensions](https://learn.microsoft.com/openspecs/windows_protocols/ms-kile/2a32282e-6ab7-4f56-b532-870c74e1c653)