### PR TITLE
fix: Handle 'No events were found' as successful query, not failure

### DIFF
--- a/Tests/Unit/Get-EventLogEncryptionAnalysis.Tests.ps1
+++ b/Tests/Unit/Get-EventLogEncryptionAnalysis.Tests.ps1
@@ -69,6 +69,31 @@ Describe 'Get-EventLogEncryptionAnalysis' {
         }
     }
 
+    Context 'When Invoke-Command throws "No events were found"' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADDomainController {
+                @([PSCustomObject]@{ Name = 'DC01'; HostName = 'dc01.contoso.com'; ComputerObjectDN = 'CN=DC01,OU=Domain Controllers,DC=contoso,DC=com' })
+            }
+            Mock -ModuleName 'RC4-ADAssessment' Test-Connection { $true }
+            Mock -ModuleName 'RC4-ADAssessment' Invoke-Command {
+                throw 'No events were found that match the specified selection criteria.'
+            }
+        }
+
+        It 'Treats DC as successfully queried, not failed' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.QueriedDCs | Should -Contain 'dc01.contoso.com'
+            $result.FailedDCs.Count | Should -Be 0
+        }
+
+        It 'Returns zero ticket counts' {
+            $result = Get-EventLogEncryptionAnalysis -ServerParams @{}
+            $result.RC4Tickets | Should -Be 0
+            $result.AESTickets | Should -Be 0
+            $result.EventsAnalyzed | Should -Be 0
+        }
+    }
+
     Context 'When events contain mixed ticket and session key encryption types' {
         BeforeEach {
             Mock -ModuleName 'RC4-ADAssessment' Get-ADDomainController {

--- a/source/Private/Get-EventLogEncryptionAnalysis.ps1
+++ b/source/Private/Get-EventLogEncryptionAnalysis.ps1
@@ -1,4 +1,4 @@
-function Get-EventLogEncryptionAnalysis {
+﻿function Get-EventLogEncryptionAnalysis {
     <#
     .SYNOPSIS
         Analyses Kerberos event logs on Domain Controllers to detect DES and RC4 ticket usage.
@@ -140,18 +140,30 @@ function Get-EventLogEncryptionAnalysis {
                     $usedWinRM = $true
                 }
                 catch {
-                    # WinRM failed, try RPC as fallback
-                    Write-Host "    $([char]0x26A0) WinRM unavailable on $dcName, trying RPC..." -ForegroundColor DarkYellow
-
-                    try {
-                        $events = Get-WinEvent -ComputerName $dcName -FilterXml $filterXml -MaxEvents 1000 -ErrorAction Stop
+                    if ($_.Exception.Message -match 'No events were found') {
+                        # Query succeeded but no matching events — not a failure
+                        $events = @()
+                        $usedWinRM = $true
                     }
-                    catch {
-                        throw $_
+                    else {
+                        # WinRM failed, try RPC as fallback
+                        Write-Host "    $([char]0x26A0) WinRM unavailable on $dcName, trying RPC..." -ForegroundColor DarkYellow
+
+                        try {
+                            $events = Get-WinEvent -ComputerName $dcName -FilterXml $filterXml -MaxEvents 1000 -ErrorAction Stop
+                        }
+                        catch {
+                            if ($_.Exception.Message -match 'No events were found') {
+                                $events = @()
+                            }
+                            else {
+                                throw $_
+                            }
+                        }
                     }
                 }
 
-                if (-not $events) {
+                if (-not $events -or @($events).Count -eq 0) {
                     Write-Host "    $([char]0x24D8) No events found on $dcName" -ForegroundColor Gray
                     $assessment.QueriedDCs += $dcName  # Still track as successfully queried
                     $assessment.PerDcStats[$dcName] = @{ EventsAnalyzed = 0; RC4Tickets = 0; DESTickets = 0; AESTickets = 0; SessionKeyRC4 = 0; SessionKeyDES = 0; SessionKeyAES = 0 }


### PR DESCRIPTION
## Problem

When `Get-WinEvent` finds no matching 4768/4769 events in the time window (e.g., all prerequisites configured but no Kerberos activity), it throws:

> *No events were found that match the specified selection criteria.*

This terminating error was caught by the generic `catch` block and the DC was added to **FailedDCs** (red) instead of **QueriedDCs** (green) — making it look like the event log query failed when it actually succeeded.

## Fix

- Catch `'No events were found'` in both the WinRM (`Invoke-Command`) and RPC (`Get-WinEvent`) code paths
- Treat as an empty result set (`\ = @()`) instead of a failure
- Empty array check uses `@(\).Count -eq 0` for PS 5.1/7 consistency
- Fixed `PSUseBOMForUnicodeEncodedFile` PSScriptAnalyzer warning (UTF-8 BOM)

## Tests

- 2 new unit tests: DC appears in `QueriedDCs` (not `FailedDCs`), zero ticket counts
- All **488 tests pass** (0 failures, 61% code coverage)

## Pattern match

This follows the same error-handling pattern already used in `Get-KdcSvcEventAssessment.ps1` (KDCSVC events 201-209).