### PR TITLE
fix: clarify RC4DefaultDisablementPhase=1 is checkpoint, not event gate

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -120,7 +120,7 @@ KDC Registry Configuration Assessment
 ────────────────────────────────────────────────────────────────
 ℹ️  DefaultDomainSupportedEncTypes: Not set (uses OS defaults)
 ⚠️  RC4DefaultDisablementPhase not set
-   Deploy January 2026+ security updates, then set to 1 to enable KDCSVC audit events
+   Deploy January 2026+ security updates, then set to 1 (checkpoint) before enabling Enforcement (value 2)
 
 KDCSVC System Event Assessment (CVE-2026-20833)
 ────────────────────────────────────────────────────────────────
@@ -139,10 +139,10 @@ Overall Security Assessment
   Recommendations & Remediation:
     • WARNING: [contoso.com] RC4DefaultDisablementPhase not set
       # Step 1: Deploy January 2026+ security updates on all DCs
-      # Step 2: Enable KDCSVC audit events (System log events 201-209):
+      # Step 2: Set RC4DefaultDisablementPhase to 1 (administrative checkpoint before enforcement):
       PS> Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Kdc' `
             -Name 'RC4DefaultDisablementPhase' -Value 1 -Type DWord
-      # Step 3: Monitor KDCSVC events and remediate any RC4 dependencies
+      # Step 3: Monitor KDCSVC events 201-209 (logged automatically after installing the security update)
       # Step 4: When audit events are clear, enable Enforcement mode (value 2)
 
   💡 Tip: Use -IncludeGuidance for the full reference manual

--- a/source/Private/Get-KdcRegistryAssessment.ps1
+++ b/source/Private/Get-KdcRegistryAssessment.ps1
@@ -157,12 +157,12 @@ function Get-KdcRegistryAssessment {
                 0 {
                     $assessment.RC4DefaultDisablementPhase.Status = "WARNING"
                     Write-Finding -Status "WARNING" -Message "RC4DefaultDisablementPhase = 0 (RC4 disablement NOT active)" `
-                        -Detail "Set to 1 first to enable KDCSVC audit events 201-209, monitor, then set to 2 for Enforcement (CVE-2026-20833)"
+                        -Detail "Set to 1 (checkpoint), then 2 for Enforcement. KDCSVC audit events are logged after installing the security update regardless of this value (CVE-2026-20833)"
                 }
                 1 {
                     $assessment.RC4DefaultDisablementPhase.Status = "OK"
-                    Write-Finding -Status "OK" -Message "RC4DefaultDisablementPhase = 1 (Audit mode active - KDCSVC events 201-209 enabled)" `
-                        -Detail "Monitor KDCSVC events in System log. When no audit events remain, set to 2 for Enforcement (CVE-2026-20833)"
+                    Write-Finding -Status "OK" -Message "RC4DefaultDisablementPhase = 1 (Audit checkpoint active)" `
+                        -Detail "Monitor KDCSVC events 201-209 in System log. When no audit events remain, set to 2 for Enforcement (CVE-2026-20833)"
                 }
                 2 {
                     $assessment.RC4DefaultDisablementPhase.Status = "OK"
@@ -179,7 +179,7 @@ function Get-KdcRegistryAssessment {
         else {
             $assessment.RC4DefaultDisablementPhase.Status = "NOT SET"
             Write-Finding -Status "WARNING" -Message "RC4DefaultDisablementPhase registry key is not set" `
-                -Detail "Deploy January 2026+ security updates, then set to 1 to enable KDCSVC audit events (CVE-2026-20833)"
+                -Detail "Deploy January 2026+ security updates, then set to 1 (checkpoint) before enabling Enforcement (value 2). KDCSVC audit events are logged automatically after installing the update (CVE-2026-20833)"
         }
 
         if ($assessment.FailedDCs.Count -gt 0) {

--- a/source/Public/Invoke-RC4Assessment.ps1
+++ b/source/Public/Invoke-RC4Assessment.ps1
@@ -617,9 +617,9 @@ try {
                 Message = "[$($results.Domain)] $phaseMsg"
                 Fix     = @(
                     "# Step 1: Deploy January 2026+ security updates on all DCs"
-                    "# Step 2: Enable KDCSVC audit events (System log events 201-209):"
+                    "# Step 2: Set RC4DefaultDisablementPhase to 1 (administrative checkpoint before enforcement):"
                     "Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Kdc' -Name 'RC4DefaultDisablementPhase' -Value 1 -Type DWord"
-                    "# Step 3: Monitor KDCSVC events and remediate any RC4 dependencies"
+                    "# Step 3: Monitor KDCSVC events 201-209 (logged automatically after installing the security update)"
                     "# Step 4: When audit events are clear, enable Enforcement mode (value 2)"
                 )
             }


### PR DESCRIPTION
## Summary

KDCSVC audit events 201-209 are logged by the January 2026+ security update **regardless** of \RC4DefaultDisablementPhase\. Phase 1 is an administrative checkpoint for change management, not a technical gate for event logging. Only phase 2 changes KDC behaviour (enforcement).

### Changes

| File | Change |
|---|---|
| \source/Public/Invoke-RC4Assessment.ps1\ | Updated inline fix commands: Step 2 no longer says 'Enable KDCSVC audit events' |
| \source/Private/Get-KdcRegistryAssessment.ps1\ | Updated status messages for phase 0, 1, and not-set |
| \QUICK_START.md\ | Sample output updated to match new source text |

### Tests
All 492 tests pass — no assertions on recommendation text strings.
