### PR TITLE
feat(trust): add human-readable direction labels to trust details

### DIFF
--- a/Tests/Unit/Get-TrustEncryptionAssessment.Tests.ps1
+++ b/Tests/Unit/Get-TrustEncryptionAssessment.Tests.ps1
@@ -33,6 +33,7 @@ Describe 'Get-TrustEncryptionAssessment' {
                 @([PSCustomObject]@{
                     Name = 'partner.com'
                     Direction = 'BiDirectional'
+                    TrustDirection = 3
                     TrustType = 'Forest'
                     'msDS-SupportedEncryptionTypes' = 24
                 })
@@ -48,6 +49,11 @@ Describe 'Get-TrustEncryptionAssessment' {
             $result = Get-TrustEncryptionAssessment -ServerParams @{}
             $result.RC4Risk | Should -Be 0
         }
+
+        It 'Includes direction label in details' {
+            $result = Get-TrustEncryptionAssessment -ServerParams @{}
+            $result.Details[0].Direction | Should -Be '3 (Bidirectional)'
+        }
     }
 
     Context 'When a trust has RC4 only' {
@@ -56,6 +62,7 @@ Describe 'Get-TrustEncryptionAssessment' {
                 @([PSCustomObject]@{
                     Name = 'legacy.com'
                     Direction = 'Outbound'
+                    TrustDirection = 2
                     TrustType = 'External'
                     'msDS-SupportedEncryptionTypes' = 4
                 })
@@ -65,6 +72,11 @@ Describe 'Get-TrustEncryptionAssessment' {
         It 'Reports RC4 risk' {
             $result = Get-TrustEncryptionAssessment -ServerParams @{}
             $result.RC4Risk | Should -Be 1
+        }
+
+        It 'Includes direction label in details' {
+            $result = Get-TrustEncryptionAssessment -ServerParams @{}
+            $result.Details[0].Direction | Should -Be '2 (Outbound)'
         }
     }
 }

--- a/source/Private/Get-TrustEncryptionAssessment.ps1
+++ b/source/Private/Get-TrustEncryptionAssessment.ps1
@@ -62,9 +62,36 @@ function Get-TrustEncryptionAssessment {
             $encValue = $trust.'msDS-SupportedEncryptionTypes'
             $encTypes = Get-EncryptionTypeString -Value $encValue
 
+            # Map TrustDirection integer to human-readable label
+            $directionLabels = @{
+                0 = 'Disabled'
+                1 = 'Inbound'
+                2 = 'Outbound'
+                3 = 'Bidirectional'
+            }
+            $rawDir = $trust.TrustDirection
+            $dirValue = $rawDir -as [int]
+            if ($null -eq $dirValue) {
+                # TrustDirection is a string (e.g. AD enum); resolve to integer
+                $dirValue = switch ([string]$rawDir) {
+                    'Disabled'      { 0 }
+                    'Inbound'       { 1 }
+                    'Outbound'      { 2 }
+                    'Bidirectional' { 3 }
+                    'BiDirectional' { 3 }
+                    default         { -1 }
+                }
+            }
+            $dirLabel = if ($directionLabels.ContainsKey($dirValue)) {
+                $directionLabels[$dirValue]
+            }
+            else {
+                'Unknown'
+            }
+
             $trustInfo = @{
                 Name                 = $trust.Name
-                Direction            = $trust.TrustDirection
+                Direction            = '{0} ({1})' -f $dirValue, $dirLabel
                 Type                 = $trust.TrustType
                 EncryptionValue      = $encValue
                 EncryptionTypes      = $encTypes


### PR DESCRIPTION
## Summary

Adds human-readable direction labels (e.g. \3 (Bidirectional)\, \2 (Outbound)\) to the trust assessment \Details\ output, replacing raw integer values.

## Changes

- **\Get-TrustEncryptionAssessment.ps1\**: Map \TrustDirection\ to \'{int} ({label})'\ format. Handles both integer and string enum values from \Get-ADTrust\ using safe \-as [int]\ casting with a \switch\ fallback.
- **\Get-TrustEncryptionAssessment.Tests.ps1\**: Add Pester tests verifying direction labels appear correctly in \Details[].Direction\.

## Testing

- All 494 Pester tests pass (0 failures)
- Code coverage: 61.76% (threshold: 50%)
- Build succeeded: 17 tasks, 0 errors, 0 warnings