### PR TITLE
fix: use correct domain name in export filenames for multi-forest scans

### DIFF
--- a/source/Public/Invoke-RC4Assessment.ps1
+++ b/source/Public/Invoke-RC4Assessment.ps1
@@ -130,11 +130,28 @@ elseif ($PSBoundParameters.ContainsKey('Server')) {
     }
 }
 
+# Resolve domain name: explicit -Domain wins, then query the target server, then fall back to caller's domain
+$resolvedDomainName = if ($Domain) {
+    $Domain
+}
+elseif ($Server) {
+    try {
+        (Get-ADDomain @serverParams).DNSRoot
+    }
+    catch {
+        Write-Verbose "Could not resolve domain from server '$Server': $($_.Exception.Message)"
+        (Get-ADDomain).DNSRoot
+    }
+}
+else {
+    (Get-ADDomain).DNSRoot
+}
+
 # Initialize results object
 $results = @{
     AssessmentDate    = $script:AssessmentTimestamp
     Version           = $script:Version
-    Domain            = if ($Domain) { $Domain } else { (Get-ADDomain).DNSRoot }
+    Domain            = $resolvedDomainName
     DomainControllers = $null
     Trusts            = $null
     Accounts          = $null

--- a/source/Public/Invoke-RC4ForestAssessment.ps1
+++ b/source/Public/Invoke-RC4ForestAssessment.ps1
@@ -164,16 +164,15 @@
             Write-Host "  Warning: This may fail for child domains if not directly reachable" -ForegroundColor Yellow
         }
 
-        # Build command parameters
-        $params = @{}
+        # Build command parameters — always pass -Domain so the assessed domain
+        # name appears in results and export filenames (not the caller's domain).
+        $params = @{
+            Domain = $DomainName
+        }
 
         if ($serverParam) {
-            # Use -Server with the discovered DC hostname
+            # Also use -Server with the discovered DC hostname
             $params['Server'] = $serverParam
-        }
-        else {
-            # Fall back to -Domain
-            $params['Domain'] = $DomainName
         }
 
         if ($AnalyzeLogs) {
@@ -397,13 +396,19 @@
         $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
         $forestSafe = $forest.Name -replace '\.', '_'
 
+        # Create Exports folder if it doesn't exist (consistent with Invoke-RC4Assessment)
+        $exportFolder = Join-Path -Path $PWD -ChildPath "Exports"
+        if (-not (Test-Path -Path $exportFolder)) {
+            New-Item -Path $exportFolder -ItemType Directory -Force | Out-Null
+        }
+
         # JSON export
-        $jsonPath = ".\Forest_Assessment_${forestSafe}_${timestamp}.json"
+        $jsonPath = Join-Path -Path $exportFolder -ChildPath "Forest_Assessment_${forestSafe}_${timestamp}.json"
         $forestResults | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonPath -Encoding UTF8
         Write-Host "  $([char]0x2713) Forest summary: $jsonPath" -ForegroundColor Green
 
         # CSV export
-        $csvPath = ".\Forest_Assessment_${forestSafe}_${timestamp}.csv"
+        $csvPath = Join-Path -Path $exportFolder -ChildPath "Forest_Assessment_${forestSafe}_${timestamp}.csv"
         $csvData = foreach ($domainResult in $forestResults.DomainResults) {
             [PSCustomObject]@{
                 Forest         = $forest.Name


### PR DESCRIPTION
## Problem

When running `Invoke-RC4ForestAssessment` with `-ExportResults` across multiple domains, all per-domain CSV/JSON exports contained the **caller's domain name** instead of the actual assessed domain name. This made it impossible to distinguish exports without opening each file.

### Root Cause

`Invoke-DomainAssessment` discovered a DC via `-Server` but omitted `-Domain`, so `Invoke-RC4Assessment` fell back to `(Get-ADDomain).DNSRoot` — the logged-in user's domain — for every export filename.

## Changes

- **Invoke-RC4ForestAssessment.ps1**: `Invoke-DomainAssessment` now always passes `-Domain \` alongside `-Server`
- **Invoke-RC4Assessment.ps1**: defense-in-depth — when only `-Server` is given, resolves domain name from the target server instead of falling back to the caller's domain
- Forest summary exports now go to `Exports/` folder (consistent with per-domain exports)

## Testing

- All 494 Pester tests pass
- Code coverage 61.76% (above 50% threshold)
- Build succeeded with 0 errors, 0 warnings