### PR TITLE
fix: Use Set-ADServiceAccount for gMSA/sMSA/dMSA remediation and adjust severity levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remediation commands now note that gMSA/sMSA/dMSA require `Set-ADServiceAccount` instead
+  of `Set-ADUser` (which cannot find Managed Service Account objects). Added to all inline
+  fix commands in `Invoke-RC4Assessment`, `-IncludeGuidance` output (`Show-ManualValidationGuidance`),
+  and exported guidance text (`Get-GuidancePlainText`). Also clarifies that MSA passwords are
+  managed by AD — no manual `Set-ADAccountPassword` reset is needed; AES keys are generated
+  at the next automatic password rotation. Computer accounts already correctly use `Set-ADComputer`.
+
+### Changed
+
+- "RC4 tickets detected in event logs" downgraded from CRITICAL to WARNING — RC4 tickets may
+  originate from intentional `0x1C` exception accounts that will continue functioning after
+  July 2026 enforcement
+- "Missing AES keys" upgraded from WARNING to CRITICAL — accounts with no AES keys (explicit
+  non-AES encryption or very old passwords predating AES key generation) will break after
+  enforcement phase
+
 ## [4.9.0] - 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Overall Security Assessment
     • WARNING: [contoso.com] 1 account(s) have explicit RC4 exception (0x1C)
       # To harden: remove RC4 and set AES-only:
       PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> Set-ADAccountPassword '<AccountName>' -Reset; klist purge
       # Test application access - if it breaks, re-add RC4 exception
 
@@ -222,6 +223,7 @@ Event Log Analysis - Actual DES/RC4 Usage
       # For each account using RC4, try AES first:
       PS> Set-ADUser '<AccountName>' -Replace @{
             'msDS-SupportedEncryptionTypes'=24}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> Set-ADAccountPassword '<AccountName>' -Reset; klist purge
       # If AES fails, add explicit RC4 exception:
       #   -Replace @{'msDS-SupportedEncryptionTypes'=0x1C}
@@ -426,8 +428,10 @@ If a service absolutely cannot use AES after April/July 2026 (per [CVE-2026-2083
 ```powershell
 # Per-account exception (recommended):
 Set-ADUser 'svc_LegacyApp' -Replace @{'msDS-SupportedEncryptionTypes'=0x1C}
+# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
 # 0x1C = RC4 (0x4) + AES128 (0x8) + AES256 (0x10)
 Set-ADAccountPassword 'svc_LegacyApp' -Reset; klist purge
+# MSA passwords are managed by AD - no manual reset needed
 
 # Computer account (rare):
 Set-ADComputer 'LEGACYHOST' -Replace @{'msDS-SupportedEncryptionTypes'=0x1C}
@@ -797,6 +801,7 @@ Overall Security Assessment
       # These accounts explicitly allow RC4 (msDS-SupportedEncryptionTypes includes 0x4 + AES)
       # To harden: remove RC4 and set AES-only:
       PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> Set-ADAccountPassword '<AccountName>' -Reset; klist purge
 
     • WARNING: [contoso.com] 1 account(s) may be missing AES keys: tim (last logon: 2026-03-30)
@@ -804,6 +809,7 @@ Overall Security Assessment
       PS> Set-ADAccountPassword '<AccountName>' -Reset; klist purge
       # If AES is still not used after password reset, explicitly set AES:
       PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> Set-ADAccountPassword '<AccountName>' -Reset; klist purge
 ```
 
@@ -825,6 +831,7 @@ This account has AES keys available (confirmed by the event log). It is not flag
 > **Tip:** Remove the DES and RC4 bits to prepare for July 2026:
 > ```powershell
 > Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}
+> # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
 > Set-ADAccountPassword '<AccountName>' -Reset; klist purge
 > ```
 > `24` = `0x18` = AES128 + AES256 (AES-only).

--- a/Tests/Unit/RC4-ADAssessment.Tests.ps1
+++ b/Tests/Unit/RC4-ADAssessment.Tests.ps1
@@ -1846,14 +1846,15 @@ Describe 'Overall Assessment Scoring Logic' {
         $status | Should -Be "CRITICAL"
     }
 
-    It 'Returns CRITICAL when RC4 tickets found in event logs' {
+    It 'Returns WARNING when RC4 tickets found in event logs' {
         $criticalIssues = 0
+        $warnings = 0
         $eventResult = @{ RC4Tickets = 5 }
 
-        if ($eventResult.RC4Tickets -gt 0) { $criticalIssues++ }
+        if ($eventResult.RC4Tickets -gt 0) { $warnings++ }
 
-        $status = if ($criticalIssues -gt 0) { "CRITICAL" } else { "OK" }
-        $status | Should -Be "CRITICAL"
+        $status = if ($criticalIssues -gt 0) { "CRITICAL" } elseif ($warnings -gt 0) { "WARNING" } else { "OK" }
+        $status | Should -Be "WARNING"
     }
 
     It 'Returns WARNING when stale service accounts with RC4 exist' {
@@ -1867,15 +1868,15 @@ Describe 'Overall Assessment Scoring Logic' {
         $status | Should -Be "WARNING"
     }
 
-    It 'Returns WARNING when missing AES key accounts exist' {
+    It 'Returns CRITICAL when missing AES key accounts exist' {
         $criticalIssues = 0
         $warnings = 0
         $accountResult = @{ TotalMissingAES = 5 }
 
-        if ($accountResult.TotalMissingAES -gt 0) { $warnings++ }
+        if ($accountResult.TotalMissingAES -gt 0) { $criticalIssues++ }
 
         $status = if ($criticalIssues -gt 0) { "CRITICAL" } elseif ($warnings -gt 0) { "WARNING" } else { "OK" }
-        $status | Should -Be "WARNING"
+        $status | Should -Be "CRITICAL"
     }
 
     It 'Returns WARNING when RC4DefaultDisablementPhase is not set' {

--- a/source/Private/Get-GuidancePlainText.ps1
+++ b/source/Private/Get-GuidancePlainText.ps1
@@ -239,6 +239,7 @@ ktpass command reference:
 
    Update service accounts to AES:
    PS> Set-ADUser "ServiceAccount" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+   # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
    # Then reset the password to generate new AES keys
    # After changing encryption types, purge cached tickets:
    # CMD> klist purge
@@ -300,6 +301,7 @@ ktpass command reference:
 
    a) Step 1: Try AES First
       PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> Set-ADAccountPassword "svc_LegacyApp" -Reset
       CMD> klist purge
       * Test application access
@@ -309,6 +311,7 @@ ktpass command reference:
 
       For USER/SERVICE accounts:
       PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=0x1C}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> Set-ADAccountPassword "svc_LegacyApp" -Reset
       CMD> klist purge
       * Test application access

--- a/source/Private/Show-ManualValidationGuidance.ps1
+++ b/source/Private/Show-ManualValidationGuidance.ps1
@@ -221,6 +221,7 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
 
    Update service accounts to AES:
    PS> Set-ADUser "ServiceAccount" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+   # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
    # Then reset the password to generate new AES keys
    # IMPORTANT: After changing encryption types, purge cached tickets:
    # CMD> klist purge
@@ -285,6 +286,7 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
    a) Step 1: Try AES First
       PS> # Set account to AES-only
       PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> # Reset password to generate AES keys
       PS> Set-ADAccountPassword "svc_LegacyApp" -Reset
       CMD> klist purge
@@ -295,6 +297,7 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
 
       For USER/SERVICE accounts:
       PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=0x1C}
+      # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       # 0x1C = RC4 (0x4) + AES128 (0x8) + AES256 (0x10)
       # This allows RC4 ticket encryption while also supporting AES
       PS> Set-ADAccountPassword "svc_LegacyApp" -Reset

--- a/source/Public/Invoke-RC4Assessment.ps1
+++ b/source/Public/Invoke-RC4Assessment.ps1
@@ -310,6 +310,8 @@ try {
             Fix     = @(
                 "# Investigate each account and update to AES:"
                 "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "# For gMSA/sMSA/dMSA use Set-ADServiceAccount; for computers use Set-ADComputer"
+                "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                 "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
             )
         }
@@ -344,14 +346,16 @@ try {
     }
 
     if ($results.EventLogs -and $results.EventLogs.RC4Tickets -gt 0) {
-        $criticalIssues++
+        $warnings++
         $rc4AcctList = if ($results.EventLogs.RC4Accounts.Count -gt 0) { ($results.EventLogs.RC4Accounts | Select-Object -First 5) -join ', ' } else { 'unknown' }
         $results.Recommendations += @{
-            Level   = "CRITICAL"
+            Level   = "WARNING"
             Message = "[$($results.Domain)] RC4 tickets detected in event logs ($($results.EventLogs.RC4Tickets) tickets, accounts: $rc4AcctList)"
             Fix     = @(
                 "# For each account using RC4, try AES first:"
                 "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "# For gMSA/sMSA/dMSA use Set-ADServiceAccount; for computers use Set-ADComputer"
+                "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                 "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 "# If AES fails, add explicit RC4 exception (CVE-2026-20833 safe):"
                 "# Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x1C}"
@@ -433,6 +437,8 @@ try {
                 Fix     = @(
                     "# Update each service account to AES and reset password:"
                     "Set-ADUser '<ServiceAccount>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser"
+                    "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                     "Set-ADAccountPassword '<ServiceAccount>' -Reset; klist purge"
                     "# Update the service with the new password, then test access"
                 )
@@ -447,6 +453,9 @@ try {
                 Message = "[$($results.Domain)] $($results.Accounts.TotalRC4OnlyMSA) Managed Service Account(s) have RC4-only encryption: $msaNames"
                 Fix     = @(
                     "Set-ADServiceAccount '<MSAName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "# MSA passwords are managed by AD - no manual reset needed"
+                    "# AES keys are generated at the next automatic password rotation"
+                    "# Run 'klist purge' on the host(s) using this MSA to clear cached tickets"
                 )
             }
         }
@@ -462,6 +471,8 @@ try {
                     "# After July 2026 they will be the only accounts still able to obtain RC4 tickets"
                     "# To harden: remove RC4 and set AES-only:"
                     "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser"
+                    "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                     "# Test application access - if it breaks, re-add RC4 exception and plan vendor upgrade"
                 )
@@ -477,6 +488,8 @@ try {
                 Fix     = @(
                     "# Remove DES bits and set AES-only:"
                     "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser"
+                    "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                     "# 24 = 0x18 = AES128 + AES256 (recommended)"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 )
@@ -498,14 +511,14 @@ try {
         }
 
         if ($results.Accounts.TotalMissingAES -gt 0) {
-            $warnings++
+            $criticalIssues++
             $missingNames = ($results.Accounts.MissingAESKeyAccounts | Select-Object -First 5 | ForEach-Object {
                     $logon = if ($_.LastLogon) { " (last logon: $($_.LastLogon.ToString('yyyy-MM-dd')))" } else { " (never logged on)" }
                     "$($_.Name)$logon"
                 }) -join ', '
             $results.Recommendations += @{
-                Level   = "WARNING"
-                Message = "[$($results.Domain)] $($results.Accounts.TotalMissingAES) account(s) may be missing AES keys: $missingNames"
+                Level   = "CRITICAL"
+                Message = "[$($results.Domain)] $($results.Accounts.TotalMissingAES) account(s) may be missing AES keys (will break after enforcement): $missingNames"
                 Fix     = @(
                     "# Option 1: Reset password to generate AES keys:"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
@@ -654,6 +667,8 @@ try {
                 "# Review KDCSVC events 201-209 in System event log on each DC"
                 "# For accounts triggering events 201-203 (audit), set AES-only first:"
                 "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "# For gMSA/sMSA/dMSA use Set-ADServiceAccount; for computers use Set-ADComputer"
+                "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                 "# 24 = 0x18 = AES128 + AES256 (recommended)"
                 "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 "# If AES breaks the application, fall back to explicit RC4 exception:"


### PR DESCRIPTION
## Summary

### MSA Remediation Cmdlet Fix
Remediation commands previously used \Set-ADUser\ for all account types. gMSA/sMSA/dMSA objects cannot be found with \Set-ADUser\ — they require \Set-ADServiceAccount\. Added a clarifying comment to all affected inline fix commands across:
- \Invoke-RC4Assessment\ (recommendations)
- \Show-ManualValidationGuidance\ (-IncludeGuidance console output)
- \Get-GuidancePlainText\ (exported .txt guidance)
- \README.md\ (documentation examples)

Also clarifies that MSA passwords are managed by AD — no manual \Set-ADAccountPassword\ reset is needed. AES keys are generated at the next automatic password rotation.

### Severity Level Adjustments
- **RC4 tickets in event logs**: CRITICAL → **WARNING** — RC4 tickets may originate from intentional \