### PR TITLE
fix: show dynamic module version in all assessment banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.11.0] - 2026-04-16
+
+### Fixed
+
+- Banner version in all three public commands (`Invoke-RC4Assessment`,
+  `Invoke-RC4ForestAssessment`, `Invoke-RC4AssessmentComparison`) now dynamically
+  reads the module version from the manifest at import time, so the displayed
+  version always matches the installed release
+- `Invoke-RC4ForestAssessment` and `Invoke-RC4AssessmentComparison` banners were
+  missing the version number entirely
+- Removed stale `CHANGELOG-Surface_Laptop7.md` duplicate file
+
 ## [4.10.0] - 2026-04-15
 
 ### Fixed

--- a/source/Public/Invoke-RC4AssessmentComparison.ps1
+++ b/source/Public/Invoke-RC4AssessmentComparison.ps1
@@ -31,7 +31,7 @@ function Invoke-RC4AssessmentComparison {
 
     try {
         # Load assessment files
-        Write-ComparisonHeader "RC4/DES Assessment Comparison"
+        Write-ComparisonHeader "RC4/DES Assessment Comparison v$script:Version"
 
         Write-Host "Loading baseline: " -NoNewline -ForegroundColor White
         Write-Host $BaselineFile -ForegroundColor Cyan

--- a/source/Public/Invoke-RC4ForestAssessment.ps1
+++ b/source/Public/Invoke-RC4ForestAssessment.ps1
@@ -71,7 +71,7 @@
     }
 
     Write-Host "`n$("=" * 80)" -ForegroundColor Cyan
-    Write-Host "Active Directory Forest - DES/RC4 Assessment" -ForegroundColor Cyan
+    Write-Host "Active Directory Forest - DES/RC4 Assessment v$script:Version" -ForegroundColor Cyan
     Write-Host $("=" * 80) -ForegroundColor Cyan
 
     # Get forest information

--- a/source/prefix.ps1
+++ b/source/prefix.ps1
@@ -1,2 +1,5 @@
+# Resolve module version dynamically from the manifest that lives next to this .psm1.
+# Sampler/ModuleBuilder stamps the real version into the built .psd1, so this always
+# reflects the installed release (e.g. 4.11.0) rather than the source placeholder 0.0.1.
 $script:Version = (Import-PowerShellDataFile -Path "$PSScriptRoot\RC4-ADAssessment.psd1").ModuleVersion
 $script:AssessmentTimestamp = Get-Date


### PR DESCRIPTION
## Summary

All three public commands now display the module version dynamically from the manifest:

- **\Invoke-RC4Assessment\** — already had \\\ in banner (no change)
- **\Invoke-RC4ForestAssessment\** — banner was missing version entirely, now shows \\\
- **\Invoke-RC4AssessmentComparison\** — banner was missing version entirely, now shows \\\

### Root Cause

The \prefix.ps1\ reads \ModuleVersion\ from the \.psd1\ manifest at import time. Sampler/ModuleBuilder stamps the real version into the built manifest, so the banner correctly reflects the installed release. The forest and comparison banners simply weren't including the version at all.

### Changes

| File | Change |
|---|---|
| \source/prefix.ps1\ | Added clarifying comments; logic unchanged |
| \source/Public/Invoke-RC4ForestAssessment.ps1\ | Added \\\ to banner |
| \source/Public/Invoke-RC4AssessmentComparison.ps1\ | Added \\\ to banner |
| \CHANGELOG.md\ | Added v4.11.0 entry |

### Testing

Build succeeded, all tests pass (67% code coverage, threshold 50%).