### PR TITLE
feat: add RODC assessment support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,8 +21,8 @@ Start-Process -FilePath pwsh -ArgumentList @(
 for ($i = 0; $i -lt 120; $i++) {
     Start-Sleep 3
     if (Test-Path $logPath) {
-        $c = Get-Content $logPath -Raw -ErrorAction SilentlyContinue
-        if ($c -match 'Build (FAILED|succeeded)') {
+        $hit = Select-String -Path $logPath -Pattern 'Build (FAILED|succeeded)' -Quiet -ErrorAction SilentlyContinue
+        if ($hit) {
             Get-Content $logPath -Tail 30
             break
         }

--- a/Tests/Unit/Get-AccountEncryptionAssessment.Tests.ps1
+++ b/Tests/Unit/Get-AccountEncryptionAssessment.Tests.ps1
@@ -417,5 +417,125 @@ Describe 'Get-AccountEncryptionAssessment' {
             $result.TotalMissingAES | Should -Be 0
         }
     }
+
+    Context 'When RODC KRBTGT accounts exist' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADUser {
+                if ("$Identity" -eq 'krbtgt') {
+                    return [PSCustomObject]@{
+                        SamAccountName                  = 'krbtgt'
+                        PasswordLastSet                 = (Get-Date).AddDays(-30)
+                        pwdLastSet                      = (Get-Date).AddDays(-30).ToFileTime()
+                        'msDS-SupportedEncryptionTypes' = 24
+                        WhenChanged                     = (Get-Date).AddDays(-30)
+                    }
+                }
+                if ($Filter -and $Filter -match 'krbtgt_') {
+                    return @(
+                        [PSCustomObject]@{
+                            SamAccountName                  = 'krbtgt_12345'
+                            DistinguishedName               = 'CN=krbtgt_12345,CN=Users,DC=contoso,DC=com'
+                            PasswordLastSet                 = (Get-Date).AddDays(-90)
+                            pwdLastSet                      = (Get-Date).AddDays(-90).ToFileTime()
+                            'msDS-SupportedEncryptionTypes' = 24
+                            WhenChanged                     = (Get-Date).AddDays(-90)
+                            Enabled                         = $false
+                        },
+                        [PSCustomObject]@{
+                            SamAccountName                  = 'krbtgt_67890'
+                            DistinguishedName               = 'CN=krbtgt_67890,CN=Users,DC=contoso,DC=com'
+                            PasswordLastSet                 = (Get-Date).AddDays(-400)
+                            pwdLastSet                      = (Get-Date).AddDays(-400).ToFileTime()
+                            'msDS-SupportedEncryptionTypes' = 24
+                            WhenChanged                     = (Get-Date).AddDays(-400)
+                            Enabled                         = $false
+                        }
+                    )
+                }
+                return $null
+            }
+        }
+
+        It 'Discovers RODC KRBTGT accounts' {
+            $result = Get-AccountEncryptionAssessment -ServerParams @{}
+            $result.TotalRODCKrbtgt | Should -Be 2
+        }
+
+        It 'Reports correct password age for each RODC KRBTGT' {
+            $result = Get-AccountEncryptionAssessment -ServerParams @{}
+            $okAccount = $result.RODCKrbtgtAccounts | Where-Object { $_.Name -eq 'krbtgt_12345' }
+            $okAccount.PasswordAgeDays | Should -BeGreaterOrEqual 89
+            $okAccount.Status | Should -Be 'OK'
+        }
+
+        It 'Flags stale RODC KRBTGT passwords as CRITICAL' {
+            $result = Get-AccountEncryptionAssessment -ServerParams @{}
+            $staleAccount = $result.RODCKrbtgtAccounts | Where-Object { $_.Name -eq 'krbtgt_67890' }
+            $staleAccount.PasswordAgeDays | Should -BeGreaterOrEqual 399
+            $staleAccount.Status | Should -Be 'CRITICAL'
+        }
+    }
+
+    Context 'When no RODC KRBTGT accounts exist' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADUser {
+                if ("$Identity" -eq 'krbtgt') {
+                    return [PSCustomObject]@{
+                        SamAccountName                  = 'krbtgt'
+                        PasswordLastSet                 = (Get-Date).AddDays(-30)
+                        pwdLastSet                      = (Get-Date).AddDays(-30).ToFileTime()
+                        'msDS-SupportedEncryptionTypes' = 24
+                        WhenChanged                     = (Get-Date).AddDays(-30)
+                    }
+                }
+                if ($Filter -and $Filter -match 'krbtgt_') {
+                    return @()
+                }
+                return $null
+            }
+        }
+
+        It 'Reports zero RODC KRBTGT accounts' {
+            $result = Get-AccountEncryptionAssessment -ServerParams @{}
+            $result.TotalRODCKrbtgt | Should -Be 0
+            $result.RODCKrbtgtAccounts.Count | Should -Be 0
+        }
+    }
+
+    Context 'When RODC KRBTGT has RC4-only encryption' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADUser {
+                if ("$Identity" -eq 'krbtgt') {
+                    return [PSCustomObject]@{
+                        SamAccountName                  = 'krbtgt'
+                        PasswordLastSet                 = (Get-Date).AddDays(-30)
+                        pwdLastSet                      = (Get-Date).AddDays(-30).ToFileTime()
+                        'msDS-SupportedEncryptionTypes' = 24
+                        WhenChanged                     = (Get-Date).AddDays(-30)
+                    }
+                }
+                if ($Filter -and $Filter -match 'krbtgt_') {
+                    return @(
+                        [PSCustomObject]@{
+                            SamAccountName                  = 'krbtgt_rc4only'
+                            DistinguishedName               = 'CN=krbtgt_rc4only,CN=Users,DC=contoso,DC=com'
+                            PasswordLastSet                 = (Get-Date).AddDays(-60)
+                            pwdLastSet                      = (Get-Date).AddDays(-60).ToFileTime()
+                            'msDS-SupportedEncryptionTypes' = 4
+                            WhenChanged                     = (Get-Date).AddDays(-60)
+                            Enabled                         = $false
+                        }
+                    )
+                }
+                return $null
+            }
+        }
+
+        It 'Reports RC4-only encryption for RODC KRBTGT' {
+            $result = Get-AccountEncryptionAssessment -ServerParams @{}
+            $rc4Account = $result.RODCKrbtgtAccounts | Where-Object { $_.Name -eq 'krbtgt_rc4only' }
+            $rc4Account.EncryptionValue | Should -Be 4
+        }
+    }
 }
 }

--- a/Tests/Unit/Get-DomainControllerEncryption.Tests.ps1
+++ b/Tests/Unit/Get-DomainControllerEncryption.Tests.ps1
@@ -73,5 +73,59 @@ Describe 'Get-DomainControllerEncryption' {
             $result.RC4Configured | Should -Be 1
         }
     }
+
+    Context 'When domain has an RODC' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADDomainController {
+                @(
+                    [PSCustomObject]@{ Name = 'DC01'; HostName = 'dc01.contoso.com'; ComputerObjectDN = 'CN=DC01,OU=Domain Controllers,DC=contoso,DC=com'; IsReadOnly = $false },
+                    [PSCustomObject]@{ Name = 'RODC01'; HostName = 'rodc01.contoso.com'; ComputerObjectDN = 'CN=RODC01,OU=Domain Controllers,DC=contoso,DC=com'; IsReadOnly = $true }
+                )
+            }
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADComputer -ParameterFilter { $Identity -ne 'AzureADKerberos' } {
+                [PSCustomObject]@{ Name = 'DC'; 'msDS-SupportedEncryptionTypes' = 24; OperatingSystem = 'Windows Server 2022' }
+            }
+        }
+
+        It 'Counts RODCs separately' {
+            $result = Get-DomainControllerEncryption -ServerParams @{}
+            $result.RODCCount | Should -Be 1
+        }
+
+        It 'Still counts RODC in total DC count' {
+            $result = Get-DomainControllerEncryption -ServerParams @{}
+            $result.TotalDCs | Should -Be 2
+        }
+
+        It 'Marks the RODC detail entry as read-only' {
+            $result = Get-DomainControllerEncryption -ServerParams @{}
+            $rodcDetail = $result.Details | Where-Object { $_.Name -eq 'RODC01' }
+            $rodcDetail.IsReadOnly | Should -BeTrue
+        }
+
+        It 'Marks the RWDC detail entry as not read-only' {
+            $result = Get-DomainControllerEncryption -ServerParams @{}
+            $rwdcDetail = $result.Details | Where-Object { $_.Name -eq 'DC01' }
+            $rwdcDetail.IsReadOnly | Should -BeFalse
+        }
+    }
+
+    Context 'When no RODCs exist' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADDomainController {
+                @(
+                    [PSCustomObject]@{ Name = 'DC01'; HostName = 'dc01.contoso.com'; ComputerObjectDN = 'CN=DC01,OU=Domain Controllers,DC=contoso,DC=com'; IsReadOnly = $false }
+                )
+            }
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADComputer -ParameterFilter { $Identity -ne 'AzureADKerberos' } {
+                [PSCustomObject]@{ Name = 'DC01'; 'msDS-SupportedEncryptionTypes' = 24; OperatingSystem = 'Windows Server 2022' }
+            }
+        }
+
+        It 'Reports zero RODCs' {
+            $result = Get-DomainControllerEncryption -ServerParams @{}
+            $result.RODCCount | Should -Be 0
+        }
+    }
 }
 }

--- a/source/Private/Get-AccountEncryptionAssessment.ps1
+++ b/source/Private/Get-AccountEncryptionAssessment.ps1
@@ -55,6 +55,8 @@
         TotalDESEnabled        = 0
         TotalStaleSvc          = 0
         TotalMissingAES                   = 0
+        RODCKrbtgtAccounts                = @()
+        TotalRODCKrbtgt                   = 0
         Details                           = @()
         DeepScanRC4OnlyUsers              = @()
         DeepScanDESOnlyUsers              = @()
@@ -148,6 +150,80 @@
         }
         catch {
             Write-Finding -Status "WARNING" -Message "Could not query KRBTGT account: $($_.Exception.Message)"
+        }
+
+        # ────────────────────────────────────────────────
+        # 1b. RODC KRBTGT Accounts (krbtgt_XXXXX)
+        # ────────────────────────────────────────────────
+        Write-Host "`n  Checking RODC KRBTGT accounts (krbtgt_*)..." -ForegroundColor Cyan
+
+        try {
+            $rodcKrbtgtAccounts = @(Get-ADUser -Filter 'Name -like "krbtgt_*"' `
+                -Properties pwdLastSet, 'msDS-SupportedEncryptionTypes', PasswordLastSet, WhenChanged, Enabled @ServerParams -ErrorAction Stop)
+
+            if ($rodcKrbtgtAccounts.Count -gt 0) {
+                $assessment.TotalRODCKrbtgt = $rodcKrbtgtAccounts.Count
+                Write-Finding -Status "INFO" -Message "Found $($rodcKrbtgtAccounts.Count) RODC KRBTGT account(s)"
+
+                foreach ($rodcKrbtgt in $rodcKrbtgtAccounts) {
+                    $pwdLastSet = $rodcKrbtgt.PasswordLastSet
+                    if (-not $pwdLastSet -and $rodcKrbtgt.pwdLastSet) {
+                        $pwdLastSet = [DateTime]::FromFileTime($rodcKrbtgt.pwdLastSet)
+                    }
+
+                    $passwordAgeDays = if ($pwdLastSet) { ((Get-Date) - $pwdLastSet).Days } else { -1 }
+                    $encValue = $rodcKrbtgt.'msDS-SupportedEncryptionTypes'
+                    $encTypes = Get-EncryptionTypeString -Value $encValue
+
+                    $status = "OK"
+                    if ($passwordAgeDays -lt 0) {
+                        $status = "UNKNOWN"
+                    }
+                    elseif ($passwordAgeDays -gt 365) {
+                        $status = "CRITICAL"
+                    }
+                    elseif ($passwordAgeDays -gt 180) {
+                        $status = "WARNING"
+                    }
+
+                    $rodcInfo = @{
+                        Name             = $rodcKrbtgt.SamAccountName
+                        DN               = $rodcKrbtgt.DistinguishedName
+                        Enabled          = $rodcKrbtgt.Enabled
+                        PasswordLastSet  = $pwdLastSet
+                        PasswordAgeDays  = $passwordAgeDays
+                        EncryptionValue  = $encValue
+                        EncryptionTypes  = $encTypes
+                        Status           = $status
+                    }
+                    $assessment.RODCKrbtgtAccounts += $rodcInfo
+
+                    # Report findings per RODC KRBTGT
+                    $pwdDateStr = if ($pwdLastSet) { $pwdLastSet.ToString('yyyy-MM-dd') } else { 'Unknown' }
+                    if ($status -eq "CRITICAL") {
+                        Write-Finding -Status "CRITICAL" -Message "$($rodcKrbtgt.SamAccountName) password is $passwordAgeDays days old (last set: $pwdDateStr)" `
+                            -Detail "RODC KRBTGT passwords should be rotated at least every 180 days"
+                    }
+                    elseif ($status -eq "WARNING") {
+                        Write-Finding -Status "WARNING" -Message "$($rodcKrbtgt.SamAccountName) password is $passwordAgeDays days old (last set: $pwdDateStr)"
+                    }
+                    else {
+                        Write-Finding -Status "OK" -Message "$($rodcKrbtgt.SamAccountName) password age: $passwordAgeDays days (last set: $pwdDateStr)"
+                    }
+
+                    # Check encryption types
+                    if ($encValue -and ($encValue -band 0x4) -and -not ($encValue -band 0x18)) {
+                        Write-Finding -Status "CRITICAL" -Message "$($rodcKrbtgt.SamAccountName) has RC4-only encryption configured" `
+                            -Detail "Encryption types: $encTypes (Value: 0x$($encValue.ToString('X')))"
+                    }
+                }
+            }
+            else {
+                Write-Finding -Status "INFO" -Message "No RODC KRBTGT accounts found (no RODCs in this domain)"
+            }
+        }
+        catch {
+            Write-Finding -Status "WARNING" -Message "Could not query RODC KRBTGT accounts: $($_.Exception.Message)"
         }
 
         # ────────────────────────────────────────────────

--- a/source/Private/Get-DomainControllerEncryption.ps1
+++ b/source/Private/Get-DomainControllerEncryption.ps1
@@ -27,6 +27,7 @@ function Get-DomainControllerEncryption {
 
     $assessment = @{
         TotalDCs           = 0
+        RODCCount          = 0
         AESConfigured      = 0
         RC4Configured      = 0
         DESConfigured      = 0
@@ -86,12 +87,18 @@ function Get-DomainControllerEncryption {
             $dcComputer = Get-ADComputer $dc.ComputerObjectDN -Properties msDS-SupportedEncryptionTypes, OperatingSystem @ServerParams
             $encValue = $dcComputer.'msDS-SupportedEncryptionTypes'
             $encTypes = Get-EncryptionTypeString -Value $encValue
+            $isRODC = [bool]$dc.IsReadOnly
+
+            if ($isRODC) {
+                $assessment.RODCCount++
+            }
 
             $dcInfo = @{
                 Name            = $dc.Name
                 EncryptionValue = $encValue
                 EncryptionTypes = $encTypes
                 OperatingSystem = $dcComputer.OperatingSystem
+                IsReadOnly      = $isRODC
                 Status          = "Unknown"
             }
 
@@ -215,6 +222,9 @@ function Get-DomainControllerEncryption {
         Write-Host "  $([char]0x2022) RC4 Configured: $($assessment.RC4Configured)" -ForegroundColor $(if ($assessment.RC4Configured -gt 0) { "Yellow" } else { "Green" })
         Write-Host "  $([char]0x2022) DES Configured: $($assessment.DESConfigured)" -ForegroundColor $(if ($assessment.DESConfigured -gt 0) { "Red" } else { "Green" })
         Write-Host "  $([char]0x2022) Not Configured (GPO Inherited): $($assessment.NotConfigured)" -ForegroundColor Cyan
+        if ($assessment.RODCCount -gt 0) {
+            Write-Host "  $([char]0x2022) Read-Only DCs (RODCs): $($assessment.RODCCount)" -ForegroundColor Cyan
+        }
         if ($assessment.AzureADKerberos) {
             Write-Host "  $([char]0x2022) AzureADKerberos (Entra proxy): Excluded from DC counts (managed by Entra ID)" -ForegroundColor DarkCyan
         }
@@ -229,7 +239,8 @@ function Get-DomainControllerEncryption {
                     "DES" { "Red" }
                     default { "Cyan" }
                 }
-                Write-Host "    $([char]0x2022) $($dcInfo.Name): $($dcInfo.Status)" -ForegroundColor $statusColor
+                $rodcLabel = if ($dcInfo.IsReadOnly) { ' [RODC]' } else { '' }
+                Write-Host "    $([char]0x2022) $($dcInfo.Name)$($rodcLabel): $($dcInfo.Status)" -ForegroundColor $statusColor
                 if ($dcInfo.EncryptionValue) {
                     Write-Host "      Types: $($dcInfo.EncryptionTypes)" -ForegroundColor Gray
                 }

--- a/source/Private/Show-AssessmentSummary.ps1
+++ b/source/Private/Show-AssessmentSummary.ps1
@@ -52,6 +52,7 @@ function Show-AssessmentSummary {
 
             $dcTable += [PSCustomObject]@{
                 'Domain Controller' = $dc.Name
+                'Type'              = if ($dc.IsReadOnly) { 'RODC' } else { 'RWDC' }
                 'Status'            = $status
                 'Encryption Types'  = $dc.EncryptionTypes
                 'Attribute Value'   = if ($dc.EncryptionValue) { "0x$($dc.EncryptionValue.ToString('X'))" } else { "Not Set" }
@@ -91,6 +92,9 @@ function Show-AssessmentSummary {
         if ($Results.DomainControllers.AESConfigured -gt 0) {
             Write-Host "    AES Configured: $($Results.DomainControllers.AESConfigured)" -ForegroundColor Green
         }
+        if ($Results.DomainControllers.RODCCount -gt 0) {
+            Write-Host "    Read-Only DCs (RODCs): $($Results.DomainControllers.RODCCount)" -ForegroundColor Cyan
+        }
 
         # Display AzureADKerberos separately if present
         if ($Results.DomainControllers.AzureADKerberos) {
@@ -116,6 +120,47 @@ function Show-AssessmentSummary {
     }
     else {
         Write-Host "  No Domain Controller data available" -ForegroundColor Yellow
+    }
+
+    # 1b. RODC KRBTGT Account Summary
+    if ($Results.Accounts.RODCKrbtgtAccounts -and $Results.Accounts.RODCKrbtgtAccounts.Count -gt 0) {
+        Write-Host "`n`n  RODC KRBTGT ACCOUNT SUMMARY" -ForegroundColor Cyan
+        Write-Host ("  " + ([string]([char]0x2500) * 100)) -ForegroundColor DarkGray
+
+        $rodcTable = @()
+        foreach ($rodcK in $Results.Accounts.RODCKrbtgtAccounts) {
+            $pwdDateStr = if ($rodcK.PasswordLastSet) { $rodcK.PasswordLastSet.ToString('yyyy-MM-dd') } else { 'Unknown' }
+            $rodcTable += [PSCustomObject]@{
+                'Account'          = $rodcK.Name
+                'Status'           = $rodcK.Status
+                'Password Age'     = "$($rodcK.PasswordAgeDays) days"
+                'Password Last Set' = $pwdDateStr
+                'Encryption Types' = if ($rodcK.EncryptionTypes) { $rodcK.EncryptionTypes } else { 'Not Set (domain default)' }
+                'Enabled'          = $rodcK.Enabled
+            }
+        }
+
+        $rodcTable | Format-Table -AutoSize | Out-String -Stream | ForEach-Object {
+            if ($_ -match "CRITICAL") {
+                Write-Host "  $_" -ForegroundColor Red
+            }
+            elseif ($_ -match "WARNING") {
+                Write-Host "  $_" -ForegroundColor Yellow
+            }
+            elseif ($_ -match "OK") {
+                Write-Host "  $_" -ForegroundColor Green
+            }
+            elseif ($_ -match "Account|^-+$") {
+                Write-Host "  $_" -ForegroundColor Cyan
+            }
+            else {
+                Write-Host "  $_"
+            }
+        }
+
+        Write-Host "  $([char]0x24D8)  Each RODC has its own krbtgt_XXXXX account used to sign tickets for cached accounts." -ForegroundColor Gray
+        Write-Host "  Rotate these passwords independently from the domain-wide KRBTGT account." -ForegroundColor Gray
+        Write-Host "  Use: Reset-ComputerMachinePassword on the RODC, or reset via AD Users & Computers." -ForegroundColor Gray
     }
 
     # 2. Event Log Summary Table


### PR DESCRIPTION
## Summary
Adds Read-Only Domain Controller (RODC) assessment capabilities. Environments with RODCs now get proper visibility into RODC-specific encryption posture.

## Changes
- **Get-DomainControllerEncryption**: Track RODCCount and IsReadOnly per DC, display [RODC] label
- **Get-AccountEncryptionAssessment**: Discover and assess RODC KRBTGT accounts (krbtgt_*), check password age and encryption
- **Show-AssessmentSummary**: Add RODC KRBTGT summary table with color-coded status and rotation guidance
- **Tests**: 9 new unit tests for RODC scenarios (524 total, all passing, 67.69% coverage)
- **copilot-instructions**: Fix log polling to use Select-String instead of Get-Content -Raw