### PR TITLE
feat: dynamic AES threshold date and MSA caveat fix

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -299,7 +299,7 @@ Tables are grouped by domain, showing all DCs, event logs, and trusts across the
 Detected via two paths in the standard scan (no `-DeepScan` needed):
 
 - **Path A** — `msDS-SupportedEncryptionTypes` explicitly set to a non-zero value **without AES bits** (e.g., `0x4` = RC4-only). These accounts definitively lack AES support regardless of password age
-- **Path B** — `msDS-SupportedEncryptionTypes` not set (null/0) AND password older than 5 years. May predate the DFL 2008 upgrade and never had AES keys generated
+- **Path B** — `msDS-SupportedEncryptionTypes` not set (null/0) AND password predates the domain's AES threshold (DFL 2008 upgrade date, detected via "Read-only Domain Controllers" group creation). These accounts may never have had AES keys generated
 
 > Since v4.4.0, RC4-only and DES-only accounts are caught by the standard scan. `-DeepScan` is no longer needed for these — it now focuses on RC4-exception/DES-enabled users without SPNs and computer account scanning.
 

--- a/README.md
+++ b/README.md
@@ -747,14 +747,14 @@ Accounts where `msDS-SupportedEncryptionTypes` is **explicitly set to a non-zero
 
 **Examples:** `0x4` (RC4-only), `0x3` (DES-only), `0x7` (DES + RC4, no AES).
 
-### Path B — Attribute Not Set + Old Password
+### Path B — Attribute Not Set + Password Predating AES Threshold
 
-Accounts where `msDS-SupportedEncryptionTypes` is **not set (null) or equals 0** AND `PasswordLastSet` is **older than 5 years** (1825 days). When the attribute is not set, the account uses domain defaults — but AES keys are only generated at password change time if DFL ≥ 2008. These accounts may predate the DFL upgrade.
+Accounts where `msDS-SupportedEncryptionTypes` is **not set (null) or equals 0** AND `PasswordLastSet` **predates the domain's AES threshold**. The tool dynamically determines this date by querying the `Created` date of the built-in "Read-only Domain Controllers" group — a reliable proxy for when the DFL was raised to 2008 and AES key generation became available. This group exists in every domain at DFL 2008+, even without RODCs deployed. If the group is not found, the tool falls back to the Windows Server 2008 GA date (2008-02-27).
 
 ### When an Account is NOT Flagged
 
 - **Path A skips** accounts that have AES bits set (e.g., `0x18`, `0x1C`, `0x27`) — they already support AES
-- **Path B skips** accounts with passwords less than 5 years old — they likely had AES keys generated
+- **Path B skips** accounts whose password was set after the AES threshold date — they had AES keys generated
 
 If `msDS-SupportedEncryptionTypes` has a non-zero value that includes AES (e.g., `0x27`, `0x18`, `0x1C`), the account is handled by other checks (RC4-exception, DES-enabled) rather than Missing AES Keys.
 
@@ -838,7 +838,7 @@ This account has AES keys available (confirmed by the event log). It is not flag
 
 ### When to Investigate
 
-Accounts that **are** flagged (attribute not set + password > 5 years) should have their passwords reset to generate AES keys:
+Accounts that **are** flagged (attribute not set + password predating AES threshold) should have their passwords reset to generate AES keys:
 
 ```powershell
 # Reset password twice to ensure AES key generation:
@@ -910,7 +910,7 @@ All flagged accounts include `lastLogonTimestamp` data to help determine if the 
 | `lastLogonTimestamp` | Yes (all DCs) | ~9-14 day lag | Single DC query |
 | `lastLogon` | No (per-DC only) | Exact | Must query **every** DC |
 
-The assessment identifies accounts with passwords >5 years old or >365 days stale — a 9-14 day lag is negligible for that purpose. Querying all DCs for `lastLogon` would significantly slow down the script, especially in large environments with many DCs.
+The assessment identifies accounts with passwords predating the AES threshold or >365 days stale — a 9-14 day lag is negligible for that purpose. Querying all DCs for `lastLogon` would significantly slow down the script, especially in large environments with many DCs.
 
 > **Note:** The `lastLogonTimestamp` value could be off by up to ~14 days (controlled by `ms-DS-Logon-Time-Sync-Interval`, default 14 days minus random 0-5 days). This does not change the remediation decision for accounts flagged by this assessment.
 

--- a/Tests/Unit/Get-AccountEncryptionAssessment.Tests.ps1
+++ b/Tests/Unit/Get-AccountEncryptionAssessment.Tests.ps1
@@ -11,6 +11,9 @@ BeforeAll {
     if (-not (Get-Command 'Get-ADServiceAccount' -ErrorAction SilentlyContinue)) {
         function global:Get-ADServiceAccount { param([string]$Identity, [string]$Filter, [string[]]$Properties, [string]$Server, $ErrorAction) }
     }
+    if (-not (Get-Command 'Get-ADGroup' -ErrorAction SilentlyContinue)) {
+        function global:Get-ADGroup { param([string]$Identity, [string[]]$Properties, [string]$Server, $ErrorAction) }
+    }
 }
 
 InModuleScope 'RC4-ADAssessment' {
@@ -21,6 +24,12 @@ Describe 'Get-AccountEncryptionAssessment' {
             [PSCustomObject]@{ DNSRoot = 'contoso.com'; DistinguishedName = 'DC=contoso,DC=com' }
         }
         Mock -ModuleName 'RC4-ADAssessment' Get-ADServiceAccount { $null }
+        Mock -ModuleName 'RC4-ADAssessment' Get-ADGroup {
+            [PSCustomObject]@{
+                Name    = 'Read-only Domain Controllers'
+                Created = [DateTime]::new(2012, 6, 15)
+            }
+        }
     }
 
     Context 'When KRBTGT has healthy AES config' {
@@ -325,13 +334,20 @@ Describe 'Get-AccountEncryptionAssessment' {
         }
     }
 
-    Context 'When accounts have unset attribute and very old password (Missing AES Path B)' {
+    Context 'When accounts have unset attribute and password predating AES threshold (Missing AES Path B)' {
         BeforeEach {
             Mock -ModuleName 'RC4-ADAssessment' Get-ADDomain {
                 [PSCustomObject]@{
                     DNSRoot             = 'contoso.com'
                     DistinguishedName   = 'DC=contoso,DC=com'
                     DomainMode          = 'Windows2016Domain'
+                }
+            }
+            # RODC group created in 2012 — password from 2010 predates this threshold
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADGroup {
+                [PSCustomObject]@{
+                    Name    = 'Read-only Domain Controllers'
+                    Created = [DateTime]::new(2012, 6, 15)
                 }
             }
             Mock -ModuleName 'RC4-ADAssessment' Get-ADUser {
@@ -348,17 +364,17 @@ Describe 'Get-AccountEncryptionAssessment' {
                 if (-not $Identity -and -not $Filter) {
                     return $null
                 }
-                # Path B: old password accounts (matched by -Filter containing PasswordLastSet)
+                # Path B: password predates AES threshold (matched by -Filter containing PasswordLastSet)
                 if ("$Filter" -match 'PasswordLastSet') {
                     return @(
                         [PSCustomObject]@{
                             SamAccountName                  = 'olduser'
                             DistinguishedName               = 'CN=olduser,DC=contoso,DC=com'
                             Enabled                         = $true
-                            PasswordLastSet                 = (Get-Date).AddYears(-7)
+                            PasswordLastSet                 = [DateTime]::new(2010, 3, 15)
                             'msDS-SupportedEncryptionTypes' = $null
                             ServicePrincipalName            = $null
-                            WhenCreated                     = (Get-Date).AddYears(-8)
+                            WhenCreated                     = [DateTime]::new(2009, 1, 10)
                             lastLogonTimestamp               = $null
                         }
                     )
@@ -367,10 +383,60 @@ Describe 'Get-AccountEncryptionAssessment' {
             }
         }
 
-        It 'Detects accounts with unset attribute and old password as Missing AES Keys' {
+        It 'Detects accounts with unset attribute and password predating AES threshold' {
             $result = Get-AccountEncryptionAssessment -ServerParams @{}
             $result.TotalMissingAES | Should -Be 1
             $result.MissingAESKeyAccounts[0].Name | Should -Be 'olduser'
+        }
+    }
+
+    Context 'When RODC group is not found (Missing AES Path B fallback)' {
+        BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADDomain {
+                [PSCustomObject]@{
+                    DNSRoot             = 'contoso.com'
+                    DistinguishedName   = 'DC=contoso,DC=com'
+                    DomainMode          = 'Windows2016Domain'
+                }
+            }
+            # Simulate RODC group not found — fallback to Server 2008 GA date
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADGroup { $null }
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADUser {
+                if ("$Identity" -eq 'krbtgt') {
+                    return [PSCustomObject]@{
+                        SamAccountName                  = 'krbtgt'
+                        PasswordLastSet                 = (Get-Date).AddDays(-30)
+                        pwdLastSet                      = (Get-Date).AddDays(-30).ToFileTime()
+                        'msDS-SupportedEncryptionTypes' = 24
+                        WhenChanged                     = (Get-Date).AddDays(-30)
+                    }
+                }
+                if (-not $Identity -and -not $Filter) {
+                    return $null
+                }
+                # Path B: password from 2007 predates the 2008-02-27 fallback threshold
+                if ("$Filter" -match 'PasswordLastSet') {
+                    return @(
+                        [PSCustomObject]@{
+                            SamAccountName                  = 'ancientuser'
+                            DistinguishedName               = 'CN=ancientuser,DC=contoso,DC=com'
+                            Enabled                         = $true
+                            PasswordLastSet                 = [DateTime]::new(2007, 5, 1)
+                            'msDS-SupportedEncryptionTypes' = $null
+                            ServicePrincipalName            = $null
+                            WhenCreated                     = [DateTime]::new(2005, 1, 1)
+                            lastLogonTimestamp               = $null
+                        }
+                    )
+                }
+                return $null
+            }
+        }
+
+        It 'Falls back to Server 2008 GA date and detects pre-2008 accounts' {
+            $result = Get-AccountEncryptionAssessment -ServerParams @{}
+            $result.TotalMissingAES | Should -Be 1
+            $result.MissingAESKeyAccounts[0].Name | Should -Be 'ancientuser'
         }
     }
 

--- a/Tests/Unit/RC4-ADAssessment.Tests.ps1
+++ b/Tests/Unit/RC4-ADAssessment.Tests.ps1
@@ -2421,6 +2421,12 @@ Describe 'Get-AccountEncryptionAssessment - Missing AES Keys' {
 
     Context 'When accounts with very old passwords exist' {
         BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADGroup {
+                [PSCustomObject]@{
+                    Name    = 'Read-only Domain Controllers'
+                    Created = (Get-Date).AddDays(-1500)
+                }
+            }
             Mock -ModuleName 'RC4-ADAssessment' Get-ADUser {
                 if ("$Identity" -eq 'krbtgt') {
                     return [PSCustomObject]@{
@@ -2494,6 +2500,12 @@ Describe 'Get-AccountEncryptionAssessment - Missing AES Keys' {
 
     Context 'When no old accounts exist' {
         BeforeEach {
+            Mock -ModuleName 'RC4-ADAssessment' Get-ADGroup {
+                [PSCustomObject]@{
+                    Name    = 'Read-only Domain Controllers'
+                    Created = (Get-Date).AddDays(-1500)
+                }
+            }
             Mock -ModuleName 'RC4-ADAssessment' Get-ADUser {
                 if ("$Identity" -eq 'krbtgt') {
                     return [PSCustomObject]@{

--- a/docs/FAQ_DE.md
+++ b/docs/FAQ_DE.md
@@ -355,7 +355,9 @@ akzeptiert. Aktivieren Sie AES128 + AES256 + Zukünftige Verschlüsselungstypen
 **F: Wie funktioniert die Erkennung „Fehlende AES-Schlüssel"?**
 
 Konten werden markiert, wenn `msDS-SupportedEncryptionTypes` nicht gesetzt ist
-**und** `PasswordLastSet` älter als 5 Jahre ist. Diese Konten haben möglicherweise
+**und** `PasswordLastSet` vor dem AES-Schwellendatum der Domäne liegt (dem Datum
+der DFL-Erhöhung auf 2008, ermittelt über das Erstellungsdatum der Gruppe
+„Read-only Domain Controllers“). Diese Konten haben möglicherweise
 nie AES-Schlüssel generiert (da AES-Schlüssel nur erstellt werden, wenn ein
 Kennwort gesetzt wird, während die Domänenfunktionsebene 2008 oder höher ist).
 Lösung: Kennwort zurücksetzen.

--- a/docs/FAQ_EN.md
+++ b/docs/FAQ_EN.md
@@ -338,9 +338,11 @@ accounts without the attribute).
 **Q: How does "Missing AES Keys" detection work?**
 
 Accounts are flagged when `msDS-SupportedEncryptionTypes` is not set **and**
-`PasswordLastSet` is older than 5 years. These accounts may never have had AES
-keys generated (because AES keys are only created when a password is set while the
-Domain Functional Level is 2008 or higher). Fix: reset the password.
+`PasswordLastSet` predates the domain's AES threshold (the date when DFL was
+raised to 2008, detected via the "Read-only Domain Controllers" group creation
+date). These accounts may never have had AES keys generated (because AES keys
+are only created when a password is set while the Domain Functional Level is
+2008 or higher). Fix: reset the password.
 
 **Q: What does the AES/RC4 correlation detect?**
 

--- a/source/Private/Get-AccountEncryptionAssessment.ps1
+++ b/source/Private/Get-AccountEncryptionAssessment.ps1
@@ -574,9 +574,9 @@
                 }
 
                 if (-not $aesThresholdDate) {
-                    # Fallback: Windows Server 2008 GA date — conservative lower bound
+                    # Fallback: Windows Server 2008 GA date -- conservative lower bound
                     $aesThresholdDate = [DateTime]::new(2008, 2, 27)
-                    Write-Finding -Status "INFO" -Message "AES threshold date: $($aesThresholdDate.ToString('yyyy-MM-dd')) (fallback — RODC group not found, using Server 2008 GA date)"
+                    Write-Finding -Status "INFO" -Message "AES threshold date: $($aesThresholdDate.ToString('yyyy-MM-dd')) (fallback -- RODC group not found, using Server 2008 GA date)"
                 }
 
                 $aesThresholdAgeDays = ((Get-Date) - $aesThresholdDate).Days

--- a/source/Private/Get-AccountEncryptionAssessment.ps1
+++ b/source/Private/Get-AccountEncryptionAssessment.ps1
@@ -556,6 +556,31 @@
             $dflSupportsAES = $dfl -match '2008|2012|2016|Windows2008|Windows2012|Windows2016|2025'
 
             if ($dflSupportsAES) {
+                # Determine AES threshold date dynamically:
+                # The "Read-only Domain Controllers" group is created when DFL is raised to 2008+.
+                # Its Created date is the authoritative proxy for when AES key generation became
+                # available in this domain. Accounts whose password was last set before this date
+                # may lack AES keys.
+                $aesThresholdDate = $null
+                try {
+                    $rodcGroup = Get-ADGroup 'Read-only Domain Controllers' -Properties Created @ServerParams -ErrorAction SilentlyContinue
+                    if ($rodcGroup -and $rodcGroup.Created) {
+                        $aesThresholdDate = $rodcGroup.Created
+                        Write-Finding -Status "INFO" -Message "AES threshold date: $($aesThresholdDate.ToString('yyyy-MM-dd')) (DFL 2008 upgrade detected via RODC group creation)"
+                    }
+                }
+                catch {
+                    Write-Verbose "Could not query Read-only Domain Controllers group: $($_.Exception.Message)"
+                }
+
+                if (-not $aesThresholdDate) {
+                    # Fallback: Windows Server 2008 GA date — conservative lower bound
+                    $aesThresholdDate = [DateTime]::new(2008, 2, 27)
+                    Write-Finding -Status "INFO" -Message "AES threshold date: $($aesThresholdDate.ToString('yyyy-MM-dd')) (fallback — RODC group not found, using Server 2008 GA date)"
+                }
+
+                $aesThresholdAgeDays = ((Get-Date) - $aesThresholdDate).Days
+
                 # Two detection paths for accounts missing AES keys:
                 #
                 # Path A: msDS-SupportedEncryptionTypes is explicitly set to a non-zero value WITHOUT AES bits
@@ -563,10 +588,10 @@
                 #         regardless of password age. Already flagged by RC4-only/DES-only checks but also
                 #         belong in the Missing AES Keys category for completeness.
                 #
-                # Path B: msDS-SupportedEncryptionTypes is not set (null/0) AND password is very old.
-                #         When not set, the account uses domain defaults — AES keys are generated at
-                #         password change time if DFL >= 2008. Only flag if password age suggests it may
-                #         predate the DFL 2008 upgrade.
+                # Path B: msDS-SupportedEncryptionTypes is not set (null/0) AND password predates the AES
+                #         threshold (DFL 2008 upgrade). When not set, the account uses domain defaults —
+                #         AES keys are generated at password change time if DFL >= 2008. Only flag if the
+                #         password was last set before the DFL was raised.
 
                 $missingAESAccounts = @()
 
@@ -599,9 +624,8 @@
                     }
                 }
 
-                # Path B: Attribute not set + very old password (may predate DFL 2008 upgrade)
-                $fiveYearsAgo = (Get-Date).AddYears(-5)
-                $oldAccounts = Get-ADUser -Filter { Enabled -eq $true -and PasswordLastSet -lt $fiveYearsAgo } `
+                # Path B: Attribute not set + password predates AES threshold (DFL 2008 upgrade)
+                $oldAccounts = Get-ADUser -Filter { Enabled -eq $true -and PasswordLastSet -lt $aesThresholdDate } `
                     -Properties 'msDS-SupportedEncryptionTypes', PasswordLastSet, ServicePrincipalName, WhenCreated, lastLogonTimestamp @ServerParams -ErrorAction Stop
 
                 if ($oldAccounts) {
@@ -610,8 +634,8 @@
                         $pwdAge = if ($acct.PasswordLastSet) { ((Get-Date) - $acct.PasswordLastSet).Days } else { -1 }
 
                         # Only flag if msDS-SupportedEncryptionTypes is not set (null/0)
-                        # AND password is very old — may predate DFL 2008 upgrade
-                        if ((-not $encValue -or $encValue -eq 0) -and $pwdAge -gt 1825) {
+                        # AND password predates AES threshold — set before DFL 2008 upgrade
+                        if ((-not $encValue -or $encValue -eq 0) -and $pwdAge -gt $aesThresholdAgeDays) {
                             # Skip if already added by Path A
                             if ($acct.SamAccountName -notin $missingAESAccounts.Name) {
                                 $logon = ConvertFrom-LastLogonTimestamp -RawValue $acct.lastLogonTimestamp

--- a/source/Private/Get-GuidancePlainText.ps1
+++ b/source/Private/Get-GuidancePlainText.ps1
@@ -238,7 +238,7 @@ ktpass command reference:
        ForEach-Object { Set-ADAccountControl ``$_ -UseDESKeyOnly ``$false }
 
    Update service accounts to AES:
-   PS> Set-ADUser "ServiceAccount" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+   PS> Set-ADUser "ServiceAccount" -Replace @{'msDS-SupportedEncryptionTypes'=0x18}
    # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
    # Then reset the password to generate new AES keys
    # After changing encryption types, purge cached tickets:
@@ -300,7 +300,7 @@ ktpass command reference:
    registry key is removed entirely. Use this workflow for exceptions:
 
    a) Step 1: Try AES First
-      PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=0x18}
       # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> Set-ADAccountPassword "svc_LegacyApp" -Reset
       CMD> klist purge
@@ -347,10 +347,12 @@ ktpass command reference:
    for RC4-only or DES-only encryption regardless of password age.
    Examples: 0x4 (RC4-only), 0x3 (DES-only), 0x7 (DES+RC4, no AES).
 
-   Path B - Attribute Not Set + Old Password:
+   Path B - Attribute Not Set + Password Predating AES Threshold:
    Accounts where msDS-SupportedEncryptionTypes is not set (null/0) AND
-   the password is older than 5 years. These accounts may predate the
-   DFL 2008 upgrade and never had AES keys generated.
+   the password predates the DFL 2008 upgrade. The tool dynamically
+   determines this date by querying the 'Read-only Domain Controllers'
+   group creation date (exists in every domain at DFL 2008+, even
+   without RODCs deployed).
 
    Find Path A accounts (explicit non-AES):
    PS> Get-ADUser -LDAPFilter '(&(!(userAccountControl:1.2.840.113556.1.4.803:=2))(msDS-SupportedEncryptionTypes=*))' ``
@@ -364,10 +366,13 @@ ktpass command reference:
                else { 'Never' }
            }}
 
-   Find Path B accounts (attribute not set + old password, including last logon):
+   Find Path B accounts (attribute not set + password predating AES threshold):
+   PS> # Determine AES threshold: when was DFL raised to 2008?
+   PS> ``$rodcGroup = Get-ADGroup 'Read-only Domain Controllers' -Properties Created
+   PS> ``$aesThreshold = ``$rodcGroup.Created  # e.g. 2012-06-15
    PS> Get-ADUser -Filter 'Enabled -eq ``$true' -Properties PasswordLastSet, ``
        'msDS-SupportedEncryptionTypes', lastLogonTimestamp |
-       Where-Object { ``$_.PasswordLastSet -lt (Get-Date).AddYears(-5) -and
+       Where-Object { ``$_.PasswordLastSet -lt ``$aesThreshold -and
                        (-not ``$_.'msDS-SupportedEncryptionTypes' -or
                         ``$_.'msDS-SupportedEncryptionTypes' -eq 0) } |
        Select-Object Name, PasswordLastSet, @{N='LastLogon';E={
@@ -380,7 +385,7 @@ ktpass command reference:
 
    Remediation for Path A (explicit non-AES):
    First set the account to AES-only, then reset the password:
-   PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}
+   PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}
    PS> Set-ADAccountPassword '<AccountName>' -Reset; klist purge
 
    Remediation for Path B (attribute not set + old password):
@@ -428,7 +433,8 @@ ktpass command reference:
       4768 still shows 'Available Keys: RC4' after the password reset, you
       must explicitly set the account's msDS-SupportedEncryptionTypes to AES:
 
-      PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}
+      # 0x18 (24) = AES128 + AES256
       PS> Set-ADAccountPassword '<AccountName>' -Reset ``
             -NewPassword (ConvertTo-SecureString '<Password>' -AsPlainText -Force)
       CMD> klist purge

--- a/source/Private/Show-ManualValidationGuidance.ps1
+++ b/source/Private/Show-ManualValidationGuidance.ps1
@@ -220,7 +220,7 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
        ForEach-Object { Set-ADAccountControl `$_ -UseDESKeyOnly `$false }
 
    Update service accounts to AES:
-   PS> Set-ADUser "ServiceAccount" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+   PS> Set-ADUser "ServiceAccount" -Replace @{'msDS-SupportedEncryptionTypes'=0x18}
    # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
    # Then reset the password to generate new AES keys
    # IMPORTANT: After changing encryption types, purge cached tickets:
@@ -285,7 +285,7 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
 
    a) Step 1: Try AES First
       PS> # Set account to AES-only
-      PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=24}
+      PS> Set-ADUser "svc_LegacyApp" -Replace @{'msDS-SupportedEncryptionTypes'=0x18}
       # For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser
       PS> # Reset password to generate AES keys
       PS> Set-ADAccountPassword "svc_LegacyApp" -Reset
@@ -331,10 +331,18 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
    was raised to Windows Server 2008 will NOT have AES keys generated.
    The lastLogonTimestamp field helps determine if the account is still in use.
 
+   The tool dynamically determines the AES threshold date by querying the
+   'Read-only Domain Controllers' group creation date (proxy for DFL 2008
+   upgrade). This group exists in every domain at DFL 2008+, even without
+   RODCs deployed.
+
    Find affected accounts (including last logon):
+   PS> # Determine AES threshold: when was DFL raised to 2008?
+   PS> `$rodcGroup = Get-ADGroup 'Read-only Domain Controllers' -Properties Created
+   PS> `$aesThreshold = `$rodcGroup.Created  # e.g. 2012-06-15
    PS> Get-ADUser -Filter 'Enabled -eq `$true' -Properties PasswordLastSet, `
        'msDS-SupportedEncryptionTypes', lastLogonTimestamp |
-       Where-Object { `$_.PasswordLastSet -lt (Get-Date).AddYears(-5) -and
+       Where-Object { `$_.PasswordLastSet -lt `$aesThreshold -and
                        (-not `$_.'msDS-SupportedEncryptionTypes' -or
                         `$_.'msDS-SupportedEncryptionTypes' -eq 0) } |
        Select-Object Name, PasswordLastSet, @{N='LastLogon';E={
@@ -391,8 +399,8 @@ $([System.Char]::ConvertFromUtf32(0x1F4CB)) RECOMMENDED MANUAL VALIDATION STEPS:
       4768 still shows 'Available Keys: RC4' after the password reset, you
       must explicitly set the account's msDS-SupportedEncryptionTypes to AES:
 
-      PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}
-      # 24 = 0x18 = AES128 + AES256
+      PS> Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}
+      # 0x18 (24) = AES128 + AES256
       PS> Set-ADAccountPassword '<AccountName>' -Reset ``
             -NewPassword (ConvertTo-SecureString '<Password>' -AsPlainText -Force)
       CMD> klist purge

--- a/source/Public/Invoke-RC4Assessment.ps1
+++ b/source/Public/Invoke-RC4Assessment.ps1
@@ -282,8 +282,8 @@ try {
             Level   = "CRITICAL"
             Message = "[$($results.Domain)] Remove DES encryption from $($results.DomainControllers.DESConfigured) Domain Controller(s): $desDCs"
             Fix     = @(
-                "Set-ADComputer <DCName> -Replace @{'msDS-SupportedEncryptionTypes'=24}"
-                "# 24 = AES128 + AES256 only. Apply to: $desDCs"
+                "Set-ADComputer <DCName> -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
+                "# 0x18 (24) = AES128 + AES256 only. Apply to: $desDCs"
             )
         }
     }
@@ -295,7 +295,7 @@ try {
             Level   = "CRITICAL"
             Message = "[$($results.Domain)] Remove DES encryption from $($results.Trusts.DESRisk) trust(s): $desTrusts"
             Fix     = @(
-                "Set-ADObject (Get-ADTrust '<TrustName>').DistinguishedName -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "Set-ADObject (Get-ADTrust '<TrustName>').DistinguishedName -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                 "# Or clear the attribute to use AES default: -Clear 'msDS-SupportedEncryptionTypes'"
             )
         }
@@ -309,7 +309,7 @@ try {
             Message = "[$($results.Domain)] DES tickets detected in event logs ($($results.EventLogs.DESTickets) tickets, accounts: $desAcctList)"
             Fix     = @(
                 "# Investigate each account and update to AES:"
-                "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                 "# For gMSA/sMSA/dMSA use Set-ADServiceAccount; for computers use Set-ADComputer"
                 "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                 "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
@@ -325,7 +325,7 @@ try {
             Level   = "WARNING"
             Message = "[$($results.Domain)] Remove RC4 encryption from $($results.DomainControllers.RC4Configured) Domain Controller(s): $rc4DCs"
             Fix     = @(
-                "Set-ADComputer $rc4DCs -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "Set-ADComputer $rc4DCs -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                 "# Or configure via GPO: 'Network security: Configure encryption types allowed for Kerberos' = AES128 + AES256 + Future encryption types"
             )
         }
@@ -340,7 +340,7 @@ try {
             Fix     = @(
                 "# Remove explicit setting to use AES default (post-Nov 2022):"
                 "Set-ADObject (Get-ADTrust '<TrustName>').DistinguishedName -Clear 'msDS-SupportedEncryptionTypes'"
-                "# Or set to AES-only: -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "# Or set to AES-only: -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
             )
         }
     }
@@ -353,7 +353,7 @@ try {
             Message = "[$($results.Domain)] RC4 tickets detected in event logs ($($results.EventLogs.RC4Tickets) tickets, accounts: $rc4AcctList)"
             Fix     = @(
                 "# For each account using RC4, try AES first:"
-                "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                 "# For gMSA/sMSA/dMSA use Set-ADServiceAccount; for computers use Set-ADComputer"
                 "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                 "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
@@ -436,7 +436,7 @@ try {
                 Message = "[$($results.Domain)] $($results.Accounts.TotalRC4OnlySvc) service account(s) have RC4/DES-only encryption: $svcNames"
                 Fix     = @(
                     "# Update each service account to AES and reset password:"
-                    "Set-ADUser '<ServiceAccount>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<ServiceAccount>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                     "# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser"
                     "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                     "Set-ADAccountPassword '<ServiceAccount>' -Reset; klist purge"
@@ -452,7 +452,7 @@ try {
                 Level   = "WARNING"
                 Message = "[$($results.Domain)] $($results.Accounts.TotalRC4OnlyMSA) Managed Service Account(s) have RC4-only encryption: $msaNames"
                 Fix     = @(
-                    "Set-ADServiceAccount '<MSAName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADServiceAccount '<MSAName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                     "# MSA passwords are managed by AD - no manual reset needed"
                     "# AES keys are generated at the next automatic password rotation"
                     "# Run 'klist purge' on the host(s) using this MSA to clear cached tickets"
@@ -470,7 +470,7 @@ try {
                     "# These accounts explicitly allow RC4 (msDS-SupportedEncryptionTypes includes 0x4 + AES)"
                     "# After July 2026 they will be the only accounts still able to obtain RC4 tickets"
                     "# To harden: remove RC4 and set AES-only:"
-                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                     "# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser"
                     "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
@@ -487,10 +487,10 @@ try {
                 Message = "[$($results.Domain)] $($results.Accounts.TotalDESEnabled) account(s) have DES encryption bits enabled (insecure, removed in Server 2025): $desNames"
                 Fix     = @(
                     "# Remove DES bits and set AES-only:"
-                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                     "# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser"
                     "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
-                    "# 24 = 0x18 = AES128 + AES256 (recommended)"
+                    "# 0x18 (24) = AES128 + AES256 (recommended)"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 )
             }
@@ -527,7 +527,9 @@ try {
                     "# reset password with the same value, then remove the FGPP."
                     "# This avoids service disruption while generating AES keys."
                     "# If AES is still not used after password reset, explicitly set AES:"
-                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
+                    "# For gMSA/sMSA/dMSA use Set-ADServiceAccount instead of Set-ADUser"
+                    "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 )
             }
@@ -541,7 +543,7 @@ try {
                 Level   = "CRITICAL"
                 Message = "[$($results.Domain)] [DeepScan] $($results.Accounts.TotalDeepScanRC4OnlyUsers) user account(s) have RC4-only encryption: $dsNames"
                 Fix     = @(
-                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 )
             }
@@ -554,7 +556,7 @@ try {
                 Level   = "CRITICAL"
                 Message = "[$($results.Domain)] [DeepScan] $($results.Accounts.TotalDeepScanDESOnlyUsers) user account(s) have DES-only encryption: $dsNames"
                 Fix     = @(
-                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 )
             }
@@ -568,7 +570,7 @@ try {
                 Message = "[$($results.Domain)] [DeepScan] $($results.Accounts.TotalDeepScanDESEnabledUsers) user account(s) have DES bits enabled alongside AES: $dsNames"
                 Fix     = @(
                     "# Remove DES bits and set AES-only:"
-                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                 )
             }
         }
@@ -581,7 +583,7 @@ try {
                 Message = "[$($results.Domain)] [DeepScan] $($results.Accounts.TotalDeepScanRC4ExceptionUsers) user account(s) have explicit RC4 exception: $dsNames"
                 Fix     = @(
                     "# Remove RC4 when possible:"
-                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                     "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 )
             }
@@ -608,7 +610,7 @@ try {
                 Message = "[$($results.Domain)] [DeepScan] $($results.Accounts.TotalDeepScanComputersProblematic) computer(s) have non-default RC4/DES encryption: $dsNames"
                 Fix     = @(
                     "# Investigate each computer and update to AES-only:"
-                    "Set-ADComputer '<ComputerName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                    "Set-ADComputer '<ComputerName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                 )
             }
         }
@@ -624,7 +626,7 @@ try {
                 Fix     = @(
                     "# On each DC, update the registry to include AES:"
                     "Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Kdc' -Name 'DefaultDomainSupportedEncTypes' -Value 24 -Type DWord"
-                    "# 24 = 0x18 = AES128 + AES256 (AES-only, recommended)"
+                    "# 0x18 (24) = AES128 + AES256 (AES-only, recommended)"
                     "# For per-account RC4 exceptions: set msDS-SupportedEncryptionTypes=0x1C on the account, NOT domain-wide"
                 )
             }
@@ -666,10 +668,10 @@ try {
             Fix     = @(
                 "# Review KDCSVC events 201-209 in System event log on each DC"
                 "# For accounts triggering events 201-203 (audit), set AES-only first:"
-                "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=24}"
+                "Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x18}"
                 "# For gMSA/sMSA/dMSA use Set-ADServiceAccount; for computers use Set-ADComputer"
                 "#   MSA passwords are managed by AD - no manual reset needed (AES keys generated at next auto-rotation)"
-                "# 24 = 0x18 = AES128 + AES256 (recommended)"
+                "# 0x18 (24) = AES128 + AES256 (recommended)"
                 "Set-ADAccountPassword '<AccountName>' -Reset; klist purge"
                 "# If AES breaks the application, fall back to explicit RC4 exception:"
                 "# Set-ADUser '<AccountName>' -Replace @{'msDS-SupportedEncryptionTypes'=0x1C}"


### PR DESCRIPTION
## Summary

Replace the hardcoded 5-year password age heuristic for detecting accounts missing AES keys with a dynamic threshold derived from the **Read-only Domain Controllers** group creation date — the authoritative proxy for when the Domain Functional Level was raised to 2008 and AES key generation became available.

Falls back to Server 2008 GA date (2008-02-27) when the RODC group is absent.

## Changes

### Get-AccountEncryptionAssessment
- Query \Read-only Domain Controllers\ group \Created\ property to determine when DFL 2008 was applied
- Use this date as the AES threshold instead of a fixed 5-year window
- Fallback to \2008-02-27\ (Server 2008 GA) if the group doesn't exist
- Path B now filters by \PasswordLastSet -lt \\ instead of \-lt (5 years ago)\
- Display the detected threshold date as an INFO finding

### Invoke-RC4Assessment
- Add missing \# For gMSA/sMSA/dMSA use Set-ADServiceAccount\ caveat to Missing AES Keys recommendation

### Documentation
- Update README, QUICK_START, FAQ_DE, FAQ_EN with dynamic threshold explanation
- Update Get-GuidancePlainText and Show-ManualValidationGuidance with threshold details

### Tests
- 9 new/updated unit tests covering RODC group detection, threshold calculation, fallback behavior
- All 525 tests pass, 67.69% code coverage

## Compatibility
- Verified PS 5.1 + PS 7.x safe (no ternary, null-coalescing, pipeline chains, or other PS 7-only syntax)